### PR TITLE
removing the all powerful selector

### DIFF
--- a/EssentialCSharp.Web/wwwroot/css/styles.css
+++ b/EssentialCSharp.Web/wwwroot/css/styles.css
@@ -1,9 +1,9 @@
-html * {
-    font-family: "Roboto", Arial, Helvetica, sans-serif;
-}
-
 :root {
   --toolbar-height: 45px;
+}
+
+body {
+  font-family: "Roboto", Arial, Helvetica, sans-serif;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Description

Removing the all powerful selector to all html elements for the font family. It will now be separated into the body for the generated html pages, and the body for the website page. This will also help for editing since the web project is in a separate repo.

Linked PR for the Pages: https://github.com/IntelliTect/EssentialCSharpManuscript/pull/768

Fixes #26 
