### PR TITLE
fix: scrollbar "pop-in" causing sidebar elements to resize

### DIFF
--- a/EssentialCSharp.Web/wwwroot/css/styles.css
+++ b/EssentialCSharp.Web/wwwroot/css/styles.css
@@ -485,6 +485,7 @@ details > summary::-webkit-details-marker {
   padding-top: 15px;
   padding-right: 18px;
   padding-left: 15px;
+  scrollbar-gutter: stable;
 }
 
 /* Top Banner Bar */


### PR DESCRIPTION
## Description

Fixes an issue in the sidebar. When the scrollbar appears in the sidebar the available width of the chapter titles is slightly decreased causing elements to move when certain chapter titles sections are expanded. Set scrollbar-gutter behavior to ensure a section of the sidebar is "reserved" for the scrollbar width.

https://caniuse.com/?search=scrollbar-gutter

Before
![Animation](https://github.com/IntelliTect/EssentialCSharp.Web/assets/18077107/760ea102-79c7-4a2a-b7b5-b749012f75d4)

After
![Animation](https://github.com/IntelliTect/EssentialCSharp.Web/assets/18077107/666ebffa-bc40-4948-a69f-65e601c3c311)


### Ensure that your pull request has followed all the steps below:
- [x] Code compilation
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
