### PR TITLE
ci: Switch to use pull request target

### DIFF
--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -3,7 +3,7 @@ name: Build, Test, and Deploy EssentialCSharp.Web
 on:
   push:
     branches: [ "main" ]
-  pull_request:
+  pull_request_target:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
@@ -45,11 +45,11 @@ jobs:
         run: dotnet test --no-build --configuration Release
 
       - name: Set up Docker Buildx
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to container registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         uses: docker/login-action@v2
         with:
           registry: essentialcsharpregistry.azurecr.io
@@ -57,7 +57,7 @@ jobs:
           password: ${{ secrets.ESSENTIALCSHARPPROD_REGISTRY_PASSWORD }}
 
       - name: Build and push container image to registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         uses: docker/build-push-action@v4
         with:
           push: true
@@ -68,18 +68,18 @@ jobs:
             "nuget_auth_token=${{secrets.AZURE_DEVOPS_PAT}}"
 
       - name: dotnet publish
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         run: dotnet publish -c Release -p:PublishDir=${{github.workspace}}/DeployEssentialCSharp.Web
 
       - name: Upload artifact for deployment job
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         uses: actions/upload-artifact@v3
         with:
           name: .net-app
           path: ${{github.workspace}}/DeployEssentialCSharp.Web
 
   deploy-development:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     needs: build-and-test
     environment:
@@ -101,7 +101,7 @@ jobs:
             az containerapp update -n essentialcsharpdev -g EssentialCSharp --image essentialcsharpregistry.azurecr.io/essentialcsharp:latest
           
   deploy-production:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     needs: [build-and-test, deploy-development]
     environment:
@@ -123,7 +123,7 @@ jobs:
             az containerapp update -n essentialcsharpprod -g EssentialCSharp --image essentialcsharpregistry.azurecr.io/essentialcsharp:latest
 
   deploy-appservice-development:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     needs: build-and-test
     environment:
@@ -146,7 +146,7 @@ jobs:
           package: .
           
   deploy-appservice-production:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     needs: [build-and-test, deploy-appservice-development]
     environment:


### PR DESCRIPTION
## Description

Should allow forks to run workflow and not fail because of empty secrets.

Based on my research:

- https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

This should allow people who fork the repo to access our secrets in the run. We have to approve every workflow run still however (setting on the repo), so just be careful if they request to change something in a workflow file that they aren't accessing secrets