### PR TITLE
ci: Remove nightly deploy

### DIFF
--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request_target:
-  schedule:
-    - cron: '0 4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The emails are kind of annoying and I think this deploy is maybe unnecessary, thoughts?