### PR TITLE
fix: Going to previous page with left arrow at /home does not take you to /null

### DIFF
--- a/EssentialCSharp.Web/wwwroot/js/site.js
+++ b/EssentialCSharp.Web/wwwroot/js/site.js
@@ -152,12 +152,16 @@ const app = createApp({
         }
 
         function goToPrevious() {
-            if (!window.location.href.endsWith("/home")) {
-                window.location.href = "/" + PREVIOUS_PAGE;
+            let previousPage = PREVIOUS_PAGE;
+            if (previousPage !== null) {
+                window.location.href = "/" + previousPage;
             }
         }
         function goToNext() {
-            window.location.href = "/" + NEXT_PAGE;
+            let nextPage = NEXT_PAGE;
+            if (nextPage !== null) {
+                window.location.href = "/" + nextPage;
+            }
         }
 
         document.addEventListener("keydown", (e) => {

--- a/EssentialCSharp.Web/wwwroot/js/site.js
+++ b/EssentialCSharp.Web/wwwroot/js/site.js
@@ -152,7 +152,9 @@ const app = createApp({
         }
 
         function goToPrevious() {
-            window.location.href = "/" + PREVIOUS_PAGE;
+            if (!window.location.href.endsWith("/home")) {
+                window.location.href = "/" + PREVIOUS_PAGE;
+            }
         }
         function goToNext() {
             window.location.href = "/" + NEXT_PAGE;


### PR DESCRIPTION
## Description

site.js event watching for left arrow key now does nothing when the url ends with '/home'.

Fixes IntelliTect-dev/EssentialCSharp.Tooling#797