### PR TITLE
Fix: Tooltip and turn page buttons are not below bullet list point text

### DIFF
--- a/EssentialCSharp.Web/wwwroot/css/styles.css
+++ b/EssentialCSharp.Web/wwwroot/css/styles.css
@@ -311,6 +311,7 @@ a:hover {
   top: calc(100vh - 9rem);
   top: calc(100dvh - 9rem);
   display: flex;
+  z-index: 99999; 
   justify-content: space-between;
   position: -webkit-sticky; /* Safari */
   position: sticky;


### PR DESCRIPTION
## Description

I just added a very high z-index to turn-page, so both the turn page button and tooltip are above everything else. If there's a better number for z-index, let me know. I saw a [cool way to manage z-index on larger projects](https://www.smashingmagazine.com/2021/02/css-z-index-large-projects/), but wasn't sure what would be helpful. Setting it to 99999 seems messy to me.

Fixes #630