### PR TITLE
fix: NuGet auth config layering to fix 401 on private feed in Docker

### DIFF
--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -71,11 +71,6 @@ jobs:
           cat > /tmp/nuget-auth.config << EOF
           <?xml version="1.0" encoding="utf-8"?>
           <configuration>
-            <packageSources>
-              <clear />
-              <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-              <add key="EssentialCSharp" value="https://pkgs.dev.azure.com/intelliTect/_packaging/EssentialCSharp/nuget/v3/index.json" />
-            </packageSources>
             <packageSourceCredentials>
               <EssentialCSharp>
                 <add key="Username" value="docker" />

--- a/EssentialCSharp.Web/Dockerfile
+++ b/EssentialCSharp.Web/Dockerfile
@@ -18,12 +18,12 @@ ENV ACCESS_TO_NUGET_FEED=$ACCESS_TO_NUGET_FEED
 WORKDIR /src
 COPY . .
 COPY --from=frontend-build /frontend/EssentialCSharp.Web/wwwroot/dist ./EssentialCSharp.Web/wwwroot/dist
-RUN --mount=type=secret,id=nugetconfig \
+RUN --mount=type=secret,id=nugetconfig,required=false \
     if [ "$ACCESS_TO_NUGET_FEED" = "true" ] && [ -f /run/secrets/nugetconfig ]; then \
-      dotnet restore "EssentialCSharp.Web.slnx" --configfile /run/secrets/nugetconfig -p:AccessToNugetFeed=$ACCESS_TO_NUGET_FEED; \
-    else \
-      dotnet restore "EssentialCSharp.Web.slnx" -p:AccessToNugetFeed=$ACCESS_TO_NUGET_FEED; \
+      mkdir -p ~/.nuget/config && \
+      cp /run/secrets/nugetconfig ~/.nuget/config/credentials.config; \
     fi && \
+    dotnet restore "EssentialCSharp.Web.slnx" -p:AccessToNugetFeed=$ACCESS_TO_NUGET_FEED && \
     dotnet build "EssentialCSharp.Web.slnx" -c Release --no-restore -p:AccessToNugetFeed=$ACCESS_TO_NUGET_FEED -p:ReleaseDateAttribute=True -p:SkipFrontendBuild=true && \
     dotnet publish "EssentialCSharp.Web.slnx" -c Release -p:PublishDir=/app/publish -p:UseAppHost=false -p:SkipFrontendBuild=true --no-build
 

--- a/EssentialCSharp.Web/Dockerfile
+++ b/EssentialCSharp.Web/Dockerfile
@@ -25,7 +25,8 @@ RUN --mount=type=secret,id=nugetconfig,required=false \
     fi && \
     dotnet restore "EssentialCSharp.Web.slnx" -p:AccessToNugetFeed=$ACCESS_TO_NUGET_FEED && \
     dotnet build "EssentialCSharp.Web.slnx" -c Release --no-restore -p:AccessToNugetFeed=$ACCESS_TO_NUGET_FEED -p:ReleaseDateAttribute=True -p:SkipFrontendBuild=true && \
-    dotnet publish "EssentialCSharp.Web.slnx" -c Release -p:PublishDir=/app/publish -p:UseAppHost=false -p:SkipFrontendBuild=true --no-build
+    dotnet publish "EssentialCSharp.Web.slnx" -c Release -p:PublishDir=/app/publish -p:UseAppHost=false -p:SkipFrontendBuild=true --no-build && \
+    rm -f ~/.nuget/config/credentials.config
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
## Problem

PR #1060 merged with the `--configfile` approach for Docker NuGet auth. This approach:
- Discards the repo's `nuget.config` entirely (including `packageSourceMapping`)
- Caused 401 Unauthorized on the Azure DevOps private feed

The fixup commit from the original PR branch was never applied to main.

## Fix

Switch to **NuGet config layering** (NuGet 5.7+):
- CI generates a **credentials-only** config (no `<packageSources>`)
- Dockerfile copies it to `~/.nuget/config/credentials.config`
- NuGet merges it with the repo's `nuget.config` automatically
- `nuget.config` remains the single source of truth for feeds + `packageSourceMapping`

### Changes
- **`Dockerfile`**: `cp /run/secrets/nugetconfig ~/.nuget/config/credentials.config` instead of `--configfile`; add `required=false` on secret mount
- **`Build-Test-And-Deploy.yml`**: credentials-only generated config (no `<packageSources>` section)

## Testing
- PR build: uses `ACCESS_TO_NUGET_FEED=false` (no auth needed, verifies image builds)
- Main build: full auth path with layered config