### PR TITLE
Fix GDPR cookie consent manager

### DIFF
--- a/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
+++ b/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
@@ -64,23 +64,26 @@
     </script>
     
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css">
-    <!-- Google tag (gtag.js) - Will be activated based on consent -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-761B4BMK2R"></script>
+    <!-- Google tag (gtag.js) - Consent defaults MUST be set before gtag.js loads (Google Consent Mode v2 requirement) -->
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        
-        // Initialize gtag but don't configure until consent is given
-        gtag('js', new Date());
-        
-        // Configuration will be handled by consent manager
-        // Listen for consent manager initialization event
-        document.addEventListener('consentManagerReady', function(event) {
-            if (event.detail.hasAnalyticsConsent || !event.detail.requiresConsent) {
-                gtag('config', 'G-761B4BMK2R');
-            }
+        function gtag(){dataLayer.push(arguments);}
+        gtag('consent', 'default', {
+            analytics_storage: 'denied',
+            ad_storage: 'denied',
+            ad_user_data: 'denied',
+            ad_personalization: 'denied',
+            functionality_storage: 'granted',
+            security_storage: 'granted',
+            personalization_storage: 'denied',
+            wait_for_update: 500  // ms to hold GA pings while consent banner loads
         });
+        gtag('js', new Date());
+        // Fire unconditionally — Consent Mode v2 handles denied state with cookieless modeled pings.
+        // Cookies are only set after gtag('consent', 'update', { granted }) is called by consent-manager.js.
+        gtag('config', 'G-761B4BMK2R');
     </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-761B4BMK2R"></script>
     <script src="~/js/hcaptcha-form.js" asp-append-version="true"></script>
     <!-- hCaptcha Script -->
     <script src="https://js.hcaptcha.com/1/api.js?render=explicit&onload=ecsOnHcaptchaLoad" async defer></script>

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -1,13 +1,14 @@
 /**
  * Cookie Consent Manager for Essential C#
  * Implements Google Consent Mode v2 for Microsoft Clarity and Google Analytics
- * Compliant with GDPR requirements for EEA, UK, and Switzerland
+ * Shown to all visitors — ensures GDPR compliance globally without fragile region detection.
  */
 
 class ConsentManager {
     constructor(options = {}) {
         this.COOKIE_NAME = 'essential-csharp-consent';
         this.COOKIE_DURATION = 365; // days
+        this.CONSENT_VERSION = '2'; // Bump this to re-prompt all users when consent terms change
         this.GOOGLE_ANALYTICS_ID = options.googleAnalyticsId || 'G-761B4BMK2R';
         this.consentState = {
             analytics_storage: 'denied',
@@ -19,20 +20,20 @@ class ConsentManager {
             personalization_storage: 'denied'
         };
         
-        // Check if user is in EEA/UK/Switzerland region
-        this.requiresConsent = this.checkRegionRequiresConsent();
-        
         this.init();
     }
 
     init() {
-        // Initialize Google Consent Mode
         this.initGoogleConsentMode();
         
-        // Load saved consent preferences
+        // Load saved consent preferences (signals Clarity/GA if already consented)
         this.loadConsentPreferences();
+
+        // Always send Clarity the current consent state (denied by default for new visitors).
+        // Clarity's polyfill queues this call and delivers it when the script loads.
+        this.updateClarityConsent();
         
-        // Show banner if consent required and not yet given
+        // Show banner if no valid consent stored
         if (this.shouldShowConsentBanner()) {
             this.showConsentBanner();
         }
@@ -42,64 +43,21 @@ class ConsentManager {
     }
 
     dispatchInitializationEvent() {
-        // Create and dispatch custom event to signal consent manager is ready
         const event = new CustomEvent('consentManagerReady', {
             detail: {
                 hasAnalyticsConsent: this.hasAnalyticsConsent(),
-                hasAdvertisingConsent: this.hasAdvertisingConsent(),
-                requiresConsent: this.requiresConsent
+                hasAdvertisingConsent: this.hasAdvertisingConsent()
             }
         });
         document.dispatchEvent(event);
     }
 
     initGoogleConsentMode() {
-        // Initialize gtag if not already loaded
+        // Ensure gtag infrastructure exists — the actual 'consent default' is set inline
+        // in _Layout.cshtml before gtag.js loads (required by Google Consent Mode v2).
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         window.gtag = window.gtag || gtag;
-        
-        // Set default consent state - denial for all except essential
-        gtag('consent', 'default', this.consentState);
-    }
-
-    checkRegionRequiresConsent() {
-        // Check for forced testing via URL parameter
-        const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.get('testConsent') === 'true') {
-            return true;
-        }
-        
-        // Timezone-based region detection for GDPR compliance
-        // Users can change timezones, but this provides reasonable detection for most cases
-        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        
-        // EEA countries, UK, and Switzerland timezones
-        const requiresConsentTimezones = [
-            // Western Europe
-            'Europe/London', 'Europe/Dublin', 'Europe/Lisbon', 'Europe/Madrid', 
-            'Europe/Paris', 'Europe/Amsterdam', 'Europe/Brussels', 'Europe/Luxembourg',
-            'Europe/Zurich', 'Europe/Vienna', 'Europe/Rome', 'Europe/Vatican',
-            'Europe/San_Marino', 'Europe/Malta', 'Europe/Monaco',
-            
-            // Central Europe  
-            'Europe/Berlin', 'Europe/Prague', 'Europe/Budapest', 'Europe/Warsaw',
-            'Europe/Bratislava', 'Europe/Ljubljana', 'Europe/Zagreb', 'Europe/Belgrade',
-            'Europe/Sarajevo', 'Europe/Podgorica', 'Europe/Skopje', 'Europe/Tirane',
-            
-            // Northern Europe
-            'Europe/Stockholm', 'Europe/Oslo', 'Europe/Copenhagen', 'Europe/Helsinki',
-            'Europe/Tallinn', 'Europe/Riga', 'Europe/Vilnius', 'Europe/Reykjavik',
-            
-            // Eastern Europe
-            'Europe/Bucharest', 'Europe/Sofia', 'Europe/Athens', 'Europe/Nicosia',
-            
-            // Additional EEA territories
-            'Atlantic/Canary', 'Atlantic/Madeira', 'Atlantic/Azores',
-            'Europe/Gibraltar', 'Africa/Ceuta'
-        ];
-        
-        return requiresConsentTimezones.includes(timezone);
     }
 
     loadConsentPreferences() {
@@ -107,12 +65,18 @@ class ConsentManager {
         if (saved) {
             try {
                 const preferences = JSON.parse(saved);
+
+                // Invalidate stale consent if the version has changed — treat user as new visitor
+                if (preferences._version !== this.CONSENT_VERSION) {
+                    this.deleteCookie(this.COOKIE_NAME);
+                    return;
+                }
                 
-                // Validate and only apply known consent properties for security
+                // Validate and only apply known consent properties for security.
+                // Exclude functionality_storage and security_storage — always essential, never user-overrideable.
                 const validConsentKeys = [
                     'analytics_storage', 'ad_storage', 'ad_user_data', 
-                    'ad_personalization', 'functionality_storage', 
-                    'security_storage', 'personalization_storage'
+                    'ad_personalization', 'personalization_storage'
                 ];
                 
                 const validatedPreferences = {};
@@ -132,8 +96,11 @@ class ConsentManager {
     }
 
     shouldShowConsentBanner() {
-        // Show banner if in EEA/UK/Switzerland and no consent stored
-        return this.requiresConsent && !this.getCookie(this.COOKIE_NAME);
+        // Allow forcing the banner via URL param (useful for testing)
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('testConsent') === 'true') return true;
+        // Show to all visitors who haven't given valid consent yet
+        return !this.getCookie(this.COOKIE_NAME);
     }
 
     showConsentBanner() {
@@ -154,7 +121,7 @@ class ConsentManager {
             <div class="consent-banner-content">
                 <div class="consent-banner-text">
                     <h3>Cookie Preferences</h3>
-                    <p>We use cookies to improve your experience and analyze website usage. You can manage your preferences below.</p>
+                    <p>We use cookies to improve your experience and analyze website usage. See our <a href="https://intellitect.com/about/privacy-policy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a> for details.</p>
                 </div>
                 <div class="consent-banner-actions">
                     <button id="consent-reject-all" class="btn btn-outline-secondary me-2">Reject All</button>
@@ -272,15 +239,20 @@ class ConsentManager {
             ad_storage: advertisingChecked ? 'granted' : 'denied',
             ad_user_data: advertisingChecked ? 'granted' : 'denied',
             ad_personalization: advertisingChecked ? 'granted' : 'denied',
-            personalization_storage: analyticsChecked ? 'granted' : 'denied'
+            personalization_storage: advertisingChecked ? 'granted' : 'denied'
         };
         
         this.saveConsentAndClose();
     }
 
     saveConsentAndClose() {
-        // Save consent to cookie
-        this.setCookie(this.COOKIE_NAME, JSON.stringify(this.consentState), this.COOKIE_DURATION);
+        // Save consent with audit metadata
+        const payload = {
+            ...this.consentState,
+            _timestamp: new Date().toISOString(),
+            _version: this.CONSENT_VERSION
+        };
+        this.setCookie(this.COOKIE_NAME, JSON.stringify(payload), this.COOKIE_DURATION);
         
         // Update consent mode
         this.updateConsentMode();
@@ -290,17 +262,20 @@ class ConsentManager {
         
         // Remove banner
         this.removeConsentBanner();
+
+        // Notify layout scripts so they can fire gtag('config') on interactive consent
+        document.dispatchEvent(new CustomEvent('consentUpdated', {
+            detail: {
+                hasAnalyticsConsent: this.hasAnalyticsConsent(),
+                hasAdvertisingConsent: this.hasAdvertisingConsent()
+            }
+        }));
     }
 
     updateConsentMode() {
         if (window.gtag) {
             try {
                 gtag('consent', 'update', this.consentState);
-                
-                // Configure Google Analytics if analytics consent is granted
-                if (this.consentState.analytics_storage === 'granted') {
-                    gtag('config', 'G-761B4BMK2R');
-                }
             } catch (error) {
                 console.warn('Failed to update Google Consent Mode:', error);
             }
@@ -439,7 +414,13 @@ class ConsentManager {
     setCookie(name, value, days) {
         const expires = new Date();
         expires.setTime(expires.getTime() + (days * 24 * 60 * 60 * 1000));
-        document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Lax`;
+        const secure = window.location.protocol === 'https:' ? ';Secure' : '';
+        document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Lax${secure}`;
+    }
+
+    deleteCookie(name) {
+        const secure = window.location.protocol === 'https:' ? ';Secure' : '';
+        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;SameSite=Lax${secure}`;
     }
 
     getCookie(name) {
@@ -456,12 +437,7 @@ class ConsentManager {
     // Public API for consent preference management
     openConsentPreferences() {
         this.showConsentBanner();
-        // If banner already exists, show customize options
-        setTimeout(() => {
-            if (document.getElementById('consent-banner')) {
-                this.showCustomizeOptions();
-            }
-        }, 100);
+        this.showCustomizeOptions();
     }
 
     // Check current consent status
@@ -478,17 +454,21 @@ class ConsentManager {
         this.rejectAllConsent();
         // Also clear any existing tracking cookies
         this.clearTrackingCookies();
-        // Erase Clarity cookies according to documentation
-        if (window.clarity) {
-            clarity('consent', false);
-        }
+        // Note: Clarity consent signal is sent via updateClarityConsent() inside rejectAllConsent() → saveConsentAndClose()
     }
 
     clearTrackingCookies() {
         // Clear common tracking cookies (Google Analytics and Microsoft Clarity)
         const trackingCookies = ['_ga', '_gid', '_gat', '_clck', '_clsk', 'CLID', 'ANONCHK', 'MR', 'MUID', 'SM'];
+        const expired = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
+        // GA and Clarity cookies are often set on the root domain, so attempt deletion on both the
+        // exact hostname and the parent domain (e.g. .essentialcsharp.com)
+        const hostname = window.location.hostname;
+        const rootDomain = '.' + hostname.split('.').slice(-2).join('.');
         trackingCookies.forEach(cookieName => {
-            document.cookie = `${cookieName}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+            document.cookie = `${cookieName}=;${expired};path=/`;
+            document.cookie = `${cookieName}=;${expired};path=/;domain=${hostname}`;
+            document.cookie = `${cookieName}=;${expired};path=/;domain=${rootDomain}`;
         });
     }
 }

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -143,7 +143,7 @@ class ConsentManager {
                         <span class="consent-slider"></span>
                         <div class="consent-info">
                             <strong>Google Signals</strong>
-                            <p>Consent signals passed to Google to support analytics modeling and measurement. No advertisements are served on this site.</p>
+                            <p>Allows Google to associate your visit with your Google account for analytics modeling and cross-site measurement. No advertisements are served on this site, but Google may use this data across its services.</p>
                         </div>
                     </label>
                 </div>
@@ -457,9 +457,10 @@ class ConsentManager {
         const allCookies = [...new Set([...trackingCookies, ...ga4Cookies])];
 
         allCookies.forEach(cookieName => {
-            document.cookie = `${cookieName}=;${expired};path=/`;
+            const secure = window.location.protocol === 'https:' ? ';Secure' : '';
+            document.cookie = `${cookieName}=;${expired};path=/${secure}`;
             domains.forEach(domain => {
-                document.cookie = `${cookieName}=;${expired};path=/;domain=${domain}`;
+                document.cookie = `${cookieName}=;${expired};path=/;domain=${domain}${secure}`;
             });
         });
     }

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -25,7 +25,7 @@ class ConsentManager {
     init() {
         this.initGoogleConsentMode();
         
-        // Load saved consent preferences (signals Clarity/GA if already consented)
+        // Load saved consent preferences (signals GA if already consented)
         this.loadConsentPreferences();
 
         // Always send Clarity the current consent state (denied by default for new visitors).
@@ -36,18 +36,6 @@ class ConsentManager {
         if (this.shouldShowConsentBanner()) {
             this.showConsentBanner();
         }
-        
-        // Dispatch initialization event for other scripts to listen to
-        this.dispatchInitializationEvent();
-    }
-
-    dispatchInitializationEvent() {
-        document.dispatchEvent(new CustomEvent('consentManagerReady', {
-            detail: {
-                hasAnalyticsConsent: this.hasAnalyticsConsent(),
-                hasAdvertisingConsent: this.hasAdvertisingConsent()
-            }
-        }));
     }
 
     initGoogleConsentMode() {
@@ -155,8 +143,8 @@ class ConsentManager {
                         <input type="checkbox" id="consent-advertising">
                         <span class="consent-slider"></span>
                         <div class="consent-info">
-                            <strong>Advertising Cookies</strong>
-                            <p>Used to deliver relevant advertisements and measure their effectiveness.</p>
+                            <strong>Google Signals</strong>
+                            <p>Consent signals passed to Google to support analytics modeling and measurement. No advertisements are served on this site.</p>
                         </div>
                     </label>
                 </div>
@@ -458,7 +446,7 @@ class ConsentManager {
         // This handles multi-part TLDs (e.g. .co.uk) by trying all suffixes.
         const parts = hostname.split('.');
         const domains = [hostname];
-        for (let i = 1; i < parts.length - 1; i++) {
+        for (let i = 0; i < parts.length - 1; i++) {
             domains.push('.' + parts.slice(i).join('.'));
         }
         trackingCookies.forEach(cookieName => {

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -9,7 +9,6 @@ class ConsentManager {
         this.COOKIE_NAME = 'essential-csharp-consent';
         this.COOKIE_DURATION = 365; // days
         this.CONSENT_VERSION = '2'; // Bump this to re-prompt all users when consent terms change
-        this.GOOGLE_ANALYTICS_ID = options.googleAnalyticsId || 'G-761B4BMK2R';
         this.consentState = {
             analytics_storage: 'denied',
             ad_storage: 'denied',
@@ -43,13 +42,12 @@ class ConsentManager {
     }
 
     dispatchInitializationEvent() {
-        const event = new CustomEvent('consentManagerReady', {
+        document.dispatchEvent(new CustomEvent('consentManagerReady', {
             detail: {
                 hasAnalyticsConsent: this.hasAnalyticsConsent(),
                 hasAdvertisingConsent: this.hasAdvertisingConsent()
             }
-        });
-        document.dispatchEvent(event);
+        }));
     }
 
     initGoogleConsentMode() {
@@ -90,7 +88,9 @@ class ConsentManager {
                 this.consentState = { ...this.consentState, ...validatedPreferences };
                 this.updateConsentMode();
             } catch (e) {
+                // Malformed cookie — delete it so the banner is shown again
                 console.warn('Failed to parse consent preferences', e);
+                this.deleteCookie(this.COOKIE_NAME);
             }
         }
     }
@@ -262,14 +262,6 @@ class ConsentManager {
         
         // Remove banner
         this.removeConsentBanner();
-
-        // Notify layout scripts so they can fire gtag('config') on interactive consent
-        document.dispatchEvent(new CustomEvent('consentUpdated', {
-            detail: {
-                hasAnalyticsConsent: this.hasAnalyticsConsent(),
-                hasAdvertisingConsent: this.hasAdvertisingConsent()
-            }
-        }));
     }
 
     updateConsentMode() {
@@ -461,14 +453,19 @@ class ConsentManager {
         // Clear common tracking cookies (Google Analytics and Microsoft Clarity)
         const trackingCookies = ['_ga', '_gid', '_gat', '_clck', '_clsk', 'CLID', 'ANONCHK', 'MR', 'MUID', 'SM'];
         const expired = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
-        // GA and Clarity cookies are often set on the root domain, so attempt deletion on both the
-        // exact hostname and the parent domain (e.g. .essentialcsharp.com)
         const hostname = window.location.hostname;
-        const rootDomain = '.' + hostname.split('.').slice(-2).join('.');
+        // Build candidate domains: exact host plus progressively shorter parent domains.
+        // This handles multi-part TLDs (e.g. .co.uk) by trying all suffixes.
+        const parts = hostname.split('.');
+        const domains = [hostname];
+        for (let i = 1; i < parts.length - 1; i++) {
+            domains.push('.' + parts.slice(i).join('.'));
+        }
         trackingCookies.forEach(cookieName => {
             document.cookie = `${cookieName}=;${expired};path=/`;
-            document.cookie = `${cookieName}=;${expired};path=/;domain=${hostname}`;
-            document.cookie = `${cookieName}=;${expired};path=/;domain=${rootDomain}`;
+            domains.forEach(domain => {
+                document.cookie = `${cookieName}=;${expired};path=/;domain=${domain}`;
+            });
         });
     }
 }

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -180,7 +180,7 @@ class ConsentManager {
     showCustomizeOptions() {
         const details = document.getElementById('consent-details');
         if (details) {
-            details.style.display = details.style.display === 'none' ? 'block' : 'none';
+            details.style.display = 'block';
             
             // Load current preferences into checkboxes
             document.getElementById('consent-analytics').checked = 
@@ -394,7 +394,7 @@ class ConsentManager {
         const expires = new Date();
         expires.setTime(expires.getTime() + (days * 24 * 60 * 60 * 1000));
         const secure = window.location.protocol === 'https:' ? ';Secure' : '';
-        document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Lax${secure}`;
+        document.cookie = `${name}=${encodeURIComponent(value)};expires=${expires.toUTCString()};path=/;SameSite=Lax${secure}`;
     }
 
     deleteCookie(name) {
@@ -408,7 +408,7 @@ class ConsentManager {
         for (let i = 0; i < ca.length; i++) {
             let c = ca[i];
             while (c.charAt(0) === ' ') c = c.substring(1, c.length);
-            if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+            if (c.indexOf(nameEQ) === 0) return decodeURIComponent(c.substring(nameEQ.length, c.length));
         }
         return null;
     }

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -5,7 +5,7 @@
  */
 
 class ConsentManager {
-    constructor(options = {}) {
+    constructor() {
         this.COOKIE_NAME = 'essential-csharp-consent';
         this.COOKIE_DURATION = 365; // days
         this.CONSENT_VERSION = '2'; // Bump this to re-prompt all users when consent terms change
@@ -449,7 +449,15 @@ class ConsentManager {
         for (let i = 0; i < parts.length - 1; i++) {
             domains.push('.' + parts.slice(i).join('.'));
         }
-        trackingCookies.forEach(cookieName => {
+
+        // Also collect GA4 measurement-ID cookies (_ga_XXXXXXXX) from document.cookie
+        // since their suffix changes per-property and can't be hardcoded.
+        const ga4Cookies = document.cookie.split(';')
+            .map(c => c.trim().split('=')[0])
+            .filter(name => name.startsWith('_ga_'));
+        const allCookies = [...new Set([...trackingCookies, ...ga4Cookies])];
+
+        allCookies.forEach(cookieName => {
             document.cookie = `${cookieName}=;${expired};path=/`;
             domains.forEach(domain => {
                 document.cookie = `${cookieName}=;${expired};path=/;domain=${domain}`;
@@ -460,11 +468,7 @@ class ConsentManager {
 
 // Initialize consent manager when DOM is ready
 document.addEventListener('DOMContentLoaded', function() {
-    // Check for configuration from script tag data attributes
-    const configScript = document.querySelector('script[data-consent-config]');
-    const config = configScript ? JSON.parse(configScript.dataset.consentConfig) : {};
-    
-    window.consentManager = new ConsentManager(config);
+    window.consentManager = new ConsentManager();
 });
 
 // Global function for opening consent preferences

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -42,8 +42,7 @@ class ConsentManager {
         // Ensure gtag infrastructure exists — the actual 'consent default' is set inline
         // in _Layout.cshtml before gtag.js loads (required by Google Consent Mode v2).
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        window.gtag = window.gtag || gtag;
+        window.gtag = window.gtag || function(){window.dataLayer.push(arguments);};
     }
 
     loadConsentPreferences() {
@@ -255,7 +254,7 @@ class ConsentManager {
     updateConsentMode() {
         if (window.gtag) {
             try {
-                gtag('consent', 'update', this.consentState);
+                window.gtag('consent', 'update', this.consentState);
             } catch (error) {
                 console.warn('Failed to update Google Consent Mode:', error);
             }
@@ -266,7 +265,7 @@ class ConsentManager {
         // Send consent signal to Microsoft Clarity using Consent API v2
         if (window.clarity) {
             try {
-                clarity('consentv2', {
+                window.clarity('consentv2', {
                     ad_storage: this.consentState.ad_storage,
                     analytics_storage: this.consentState.analytics_storage
                 });


### PR DESCRIPTION
## Summary

Comprehensive overhaul of the cookie consent manager to fix GDPR compliance issues, bugs, and a broken Google Analytics integration.

## Changes

### Strategy change
- **Show consent banner to all visitors** — removes unreliable timezone-based region detection (VPN bypass gaps, missing timezones, ongoing maintenance burden). One-time banner click for non-EEA users is a worthwhile tradeoff for zero compliance liability.

### Bug fixes
- **Clarity denied signal for new visitors** — `updateClarityConsent()` was never called for first-time visitors (only on returning visitors and after interaction). Now called unconditionally in `init()` so Clarity always receives the current consent state on page load.
- **`personalization_storage` mis-grouped** — was bound to `analyticsChecked` in `saveCustomPreferences()`, should be `advertisingChecked`.
- **`gtag('config')` firing twice** — removed duplicate call; now fires unconditionally once per Google Consent Mode v2 "Advanced" pattern (GA handles denied state with cookieless modeled pings).
- **Duplicate `gtag('consent', 'default')`** — removed from `initGoogleConsentMode()`; `_Layout.cshtml` is the single owner (required to fire before `gtag.js` loads).
- **`clearTrackingCookies()` didn't clear domain-scoped cookies** — now deletes on exact hostname, root domain, and no-domain for full GA/Clarity cookie coverage.
- **`revokeAllConsent()` called conflicting Clarity v1 API** — removed `clarity('consent', false)`; `consentv2` handles it.

### Improvements
- **`wait_for_update: 500`** added to `gtag('consent', 'default')` — prevents GA from firing pings before the consent banner has a chance to render.
- **`CONSENT_VERSION = '2'`** — bumping this constant re-prompts all existing users. Stale cookies are invalidated on load.
- **`_timestamp` + `_version` stored in consent cookie** — GDPR Art. 7(1) audit trail.
- **`Secure` flag** on consent cookie (HTTPS only).
- **Privacy policy link** added to consent banner text.
- **`functionality_storage`/`security_storage` protected** — can no longer be overridden via cookie tampering.
- **`openConsentPreferences()` setTimeout removed** — direct synchronous call.

## Testing

Use `?testConsent=true` to force the banner regardless of existing consent cookie.