### PR TITLE
chat: fix Responses API tool-chaining, context limits, and streaming correctness

### DIFF
--- a/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
@@ -232,6 +232,13 @@ public partial class AIChatService
         // GetChatCompletionCore and avoids conversation branching.
         if (pendingFunctionCalls is { Count: > 0 } && mcpClient != null)
         {
+            // Guard: if the API never sent StreamingResponseCreatedUpdate, currentLegResponseId
+            // is null. Continuing would send FunctionCallOutputResponseItems referencing CallIds
+            // the server has no record of (PreviousResponseId = null), causing a 400.
+            if (currentLegResponseId is null)
+                throw new InvalidOperationException(
+                    "Cannot continue tool-call chain: the streaming leg completed with tool calls but emitted no response ID.");
+
             var continuationOptions = CloneOptionsWithPreviousResponseId(responseOptions, currentLegResponseId);
             var outputItems = new List<ResponseItem>(pendingFunctionCalls.Count);
 
@@ -387,7 +394,11 @@ public partial class AIChatService
                 }
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-                options.Tools.Add(ResponseTool.CreateFunctionTool(tool.Name, functionDescription: tool.Description, strictModeEnabled: true, functionParameters: BinaryData.FromString(tool.JsonSchema.GetRawText())));
+                // strictModeEnabled: false — MCP tool schemas come from external servers and are not
+                // guaranteed to satisfy OpenAI strict-mode constraints (all properties required,
+                // additionalProperties: false everywhere). A single non-conforming schema with
+                // strict mode enabled would cause a 400 at registration time for ALL tools.
+                options.Tools.Add(ResponseTool.CreateFunctionTool(tool.Name, functionDescription: tool.Description, strictModeEnabled: false, functionParameters: BinaryData.FromString(tool.JsonSchema.GetRawText())));
 #pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             }
         }
@@ -466,7 +477,20 @@ public partial class AIChatService
                     }
 
                     LogMcpToolCallInvoked(_Logger, functionCallItem.FunctionName, iteration, endUserId);
-                    var arguments = ParseToolArguments(functionCallItem.FunctionArguments);
+
+                    Dictionary<string, object?> arguments;
+                    try
+                    {
+                        arguments = ParseToolArguments(functionCallItem.FunctionArguments);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogMcpToolArgumentParseError(_Logger, functionCallItem.FunctionName, ex, endUserId);
+                        responseItems.Add(new FunctionCallOutputResponseItem(
+                            functionCallItem.CallId,
+                            $"Error parsing arguments for '{functionCallItem.FunctionName}': invalid JSON."));
+                        continue;
+                    }
 
                     var toolResult = await mcpClient.CallToolAsync(
                         functionCallItem.FunctionName,

--- a/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
@@ -172,7 +172,11 @@ public partial class AIChatService
         input?.Replace("<", "\u2039").Replace(">", "\u203A") ?? string.Empty;
 
     /// <summary>
-    /// Processes streaming updates from the OpenAI Responses API, handling both regular responses and function calls
+    /// Processes streaming updates from the OpenAI Responses API.
+    /// Buffers all function call items before executing them — this is critical for correctness:
+    /// if the model emits multiple parallel tool calls, firing a separate continuation per call
+    /// creates forked conversation branches. Collecting all calls and submitting all outputs
+    /// in a single continuation matches the non-streaming behavior.
     /// </summary>
     private async IAsyncEnumerable<(string text, string? responseId)> ProcessStreamingUpdatesAsync(
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -187,10 +191,14 @@ public partial class AIChatService
         // Track this leg's response ID so tool-call continuations chain from it,
         // ensuring the model's context includes the user's message + reasoning.
         string? currentLegResponseId = null;
-
-        await foreach (var update in streamingUpdates.WithCancellation(cancellationToken))
-        {
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        List<FunctionCallResponseItem>? pendingFunctionCalls = null;
+
+        // Wrap the raw stream to convert context-length API errors to our domain exception.
+        // C# does not allow yield inside a try/catch, so error remapping is done in a
+        // separate helper that puts try/catch only around MoveNextAsync.
+        await foreach (var update in RethrowContextLengthErrors(streamingUpdates, responseOptions.PreviousResponseId, cancellationToken))
+        {
             if (update is StreamingResponseCreatedUpdate created)
             {
                 // Emit the response ID early so the controller can record ownership
@@ -200,104 +208,124 @@ public partial class AIChatService
             }
             else if (update is StreamingResponseOutputItemDoneUpdate itemDone)
             {
-                // Check if this is a function call that needs to be executed
                 if (itemDone.Item is FunctionCallResponseItem functionCallItem && mcpClient != null)
                 {
                     if (toolCallDepth >= 10)
                         throw new InvalidOperationException("Maximum tool call depth exceeded.");
 
-                    // Chain the continuation from THIS leg's response ID so the model sees:
-                    //   context(outer) → userMessage + AI reasoning + funcCall (stored in currentLegResponseId)
-                    //   → [toolOutput only] → next response
-                    // Using the outer previousResponseId here would omit the user's message from context.
-                    var continuationOptions = CloneOptionsWithPreviousResponseId(responseOptions, currentLegResponseId);
-
-                    await foreach (var functionResult in ExecuteFunctionCallAsync(functionCallItem, continuationOptions, mcpClient, toolCallDepth + 1, endUserId, cancellationToken))
-                    {
-                        yield return functionResult;
-                    }
+                    // Buffer all function calls — do NOT fire continuations inline.
+                    // Sending one continuation per call would create N forked conversation
+                    // branches, each missing the other N-1 tool results.
+                    pendingFunctionCalls ??= [];
+                    pendingFunctionCalls.Add(functionCallItem);
                 }
             }
             else if (update is StreamingResponseOutputTextDeltaUpdate deltaUpdate)
             {
                 yield return (deltaUpdate.Delta.ToString(), null);
             }
-            else if (update is StreamingResponseCompletedUpdate)
+            // StreamingResponseCompletedUpdate: ResponseId already emitted above — no-op.
+        }
+
+        // After the stream completes, execute all buffered tool calls and send ALL outputs
+        // in a single continuation request. This mirrors the non-streaming loop in
+        // GetChatCompletionCore and avoids conversation branching.
+        if (pendingFunctionCalls is { Count: > 0 } && mcpClient != null)
+        {
+            var continuationOptions = CloneOptionsWithPreviousResponseId(responseOptions, currentLegResponseId);
+            var outputItems = new List<ResponseItem>(pendingFunctionCalls.Count);
+
+            foreach (var functionCallItem in pendingFunctionCalls)
             {
-                // ResponseId was already emitted from StreamingResponseCreatedUpdate at the start
-                // of this response leg — no need to emit again from the completion event.
+                outputItems.Add(await ExecuteSingleToolCallAsync(functionCallItem, toolCallDepth, endUserId, mcpClient, cancellationToken));
             }
+
+            var continuationStream = _ResponseClient.CreateResponseStreamingAsync(outputItems, continuationOptions, cancellationToken);
 #pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+            await foreach (var result in ProcessStreamingUpdatesAsync(continuationStream, continuationOptions, mcpClient, toolCallDepth + 1, endUserId, cancellationToken))
+            {
+                yield return result;
+            }
         }
     }
 
     /// <summary>
-    /// Executes a function call and streams the response
+    /// Wraps a streaming response enumerable to remap <see cref="ClientResultException"/>
+    /// context-length errors to <see cref="ConversationContextLimitExceededException"/>.
+    /// <para>
+    /// C# prohibits <c>yield return</c> inside a <c>try</c> block with a <c>catch</c> clause
+    /// (CS1626). By putting the <c>try/catch</c> only around <c>MoveNextAsync</c> and the
+    /// <c>yield return</c> outside, we satisfy the compiler while still remapping exceptions.
+    /// </para>
     /// </summary>
-    private async IAsyncEnumerable<(string text, string? responseId)> ExecuteFunctionCallAsync(
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        FunctionCallResponseItem functionCallItem,
-        ResponseCreationOptions responseOptions,
-#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        McpClient mcpClient,
-        int toolCallDepth,
-        string? endUserId = null,
+    private static async IAsyncEnumerable<StreamingResponseUpdate> RethrowContextLengthErrors(
+        IAsyncEnumerable<StreamingResponseUpdate> source,
+        string? previousResponseId,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await using var enumerator = source.GetAsyncEnumerator(cancellationToken);
+        while (true)
+        {
+            bool hasNext;
+            try { hasNext = await enumerator.MoveNextAsync(); }
+            catch (ClientResultException ex) when (IsContextLengthError(ex))
+            { throw new ConversationContextLimitExceededException(previousResponseId, ex); }
+
+            if (!hasNext) break;
+            yield return enumerator.Current; // yield return is outside try/catch — valid
+        }
+    }
+#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+    /// <summary>
+    /// Executes a single MCP tool call and returns the output item to include in the
+    /// continuation request. Handles allowlist validation and argument-parsing errors
+    /// so a single bad tool never aborts the entire continuation.
+    /// </summary>
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private async Task<ResponseItem> ExecuteSingleToolCallAsync(
+        FunctionCallResponseItem functionCallItem,
+        int toolCallDepth,
+        string? endUserId,
+        McpClient mcpClient,
+        CancellationToken cancellationToken)
     {
         // Defense-in-depth: validate tool name against static allowlist before executing.
         if (!IsMcpToolAllowed(functionCallItem.FunctionName))
         {
             LogMcpToolCallRejected(_Logger, functionCallItem.FunctionName, endUserId);
-            // Feed a benign error back to the model so it can recover gracefully.
-            // The functionCallItem is in the stored response at PreviousResponseId — only send the output.
-#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            var errorItems = new List<ResponseItem>
-            {
-                new FunctionCallOutputResponseItem(
-                    functionCallItem.CallId,
-                    $"Tool '{functionCallItem.FunctionName}' is not available.")
-            };
-#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            var recoveryStream = _ResponseClient.CreateResponseStreamingAsync(
-                errorItems, responseOptions, cancellationToken);
-            await foreach (var result in ProcessStreamingUpdatesAsync(
-                recoveryStream, responseOptions, mcpClient, toolCallDepth, endUserId, cancellationToken))
-            {
-                yield return result;
-            }
-            yield break;
+            return new FunctionCallOutputResponseItem(
+                functionCallItem.CallId,
+                $"Tool '{functionCallItem.FunctionName}' is not available.");
         }
 
         LogMcpToolCallInvokedStream(_Logger, functionCallItem.FunctionName, toolCallDepth, endUserId);
-        // A dictionary of arguments to pass to the tool. Each key represents a parameter name, and its associated value represents the argument value.
-        var arguments = ParseToolArguments(functionCallItem.FunctionArguments);
 
-        // Execute the function call using the MCP client
+        Dictionary<string, object?> arguments;
+        try
+        {
+            arguments = ParseToolArguments(functionCallItem.FunctionArguments);
+        }
+        catch (Exception ex)
+        {
+            LogMcpToolArgumentParseError(_Logger, functionCallItem.FunctionName, ex, endUserId);
+            return new FunctionCallOutputResponseItem(
+                functionCallItem.CallId,
+                $"Error parsing arguments for '{functionCallItem.FunctionName}': invalid JSON.");
+        }
+
         var toolResult = await mcpClient.CallToolAsync(
             functionCallItem.FunctionName,
             arguments: arguments,
             cancellationToken: cancellationToken);
 
-        // The functionCallItem is already stored in the server's context (referenced by
-        // responseOptions.PreviousResponseId). Only the tool output is new content.
-#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        var inputItems = new List<ResponseItem>
-        {
-            new FunctionCallOutputResponseItem(functionCallItem.CallId, McpToolResultFormatter.GetModelInput(toolResult))
-        };
-#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
-        // Stream the function call response using the same processing logic
-        var functionResponseStream = _ResponseClient.CreateResponseStreamingAsync(
-            inputItems,
-            responseOptions,
-            cancellationToken);
-
-        await foreach (var result in ProcessStreamingUpdatesAsync(functionResponseStream, responseOptions, mcpClient, toolCallDepth, endUserId, cancellationToken))
-        {
-            yield return result;
-        }
+        return new FunctionCallOutputResponseItem(
+            functionCallItem.CallId,
+            McpToolResultFormatter.GetModelInput(toolResult));
     }
+#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     /// Creates response options with optional features
@@ -330,12 +358,11 @@ public partial class AIChatService
             options.PreviousResponseId = previousResponseId;
         }
 
-        // endUserId is reserved for forwarding to Azure OpenAI for end-user attribution
-        // (Microsoft Defender prompt-shield correlation). OpenAI .NET SDK v2.7.0 does not
-        // expose ResponseCreationOptions.User; this parameter is intentionally discarded
-        // until SDK support is available.
+        // Wire up end-user ID for Azure OpenAI abuse monitoring and Microsoft Defender
+        // prompt-shield correlation. The SDK now exposes EndUserId directly.
         // See: https://learn.microsoft.com/en-us/azure/defender-for-cloud/gain-end-user-context-ai
-        _ = endUserId;
+        if (!string.IsNullOrEmpty(endUserId))
+            options.EndUserId = endUserId;
 
         // Add tools if provided
         if (tools != null)
@@ -480,9 +507,10 @@ public partial class AIChatService
     }
 
     /// <summary>
-    /// Returns a shallow clone of <paramref name="source"/> with
+    /// Returns a clone of <paramref name="source"/> with
     /// <see cref="ResponseCreationOptions.PreviousResponseId"/> replaced.
-    /// Used when chaining tool-call continuations from a specific response leg.
+    /// All behavior-affecting properties are copied so that tool-call continuation legs
+    /// produce identical generation behavior to the initial leg.
     /// </summary>
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     private static ResponseCreationOptions CloneOptionsWithPreviousResponseId(
@@ -493,10 +521,23 @@ public partial class AIChatService
         {
             Instructions = source.Instructions,
             PreviousResponseId = previousResponseId,
+            EndUserId = source.EndUserId,
             ReasoningOptions = source.ReasoningOptions,
+            MaxOutputTokenCount = source.MaxOutputTokenCount,
+            TextOptions = source.TextOptions,
+            TruncationMode = source.TruncationMode,
+            ParallelToolCallsEnabled = source.ParallelToolCallsEnabled,
+            StoredOutputEnabled = source.StoredOutputEnabled,
+            ToolChoice = source.ToolChoice,
+            Temperature = source.Temperature,
+            TopP = source.TopP,
+            ServiceTier = source.ServiceTier,
         };
         foreach (var tool in source.Tools)
             clone.Tools.Add(tool);
+        if (source.Metadata is { Count: > 0 })
+            foreach (var kvp in source.Metadata)
+                clone.Metadata[kvp.Key] = kvp.Value;
         return clone;
     }
 #pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -538,6 +579,9 @@ public partial class AIChatService
     [LoggerMessage(Level = LogLevel.Warning, Message = "AI tool call rejected — not on allowlist: tool={ToolName} user={EndUserId}")]
     private static partial void LogMcpToolCallRejected(ILogger logger, string toolName, string? endUserId);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to parse tool arguments for '{ToolName}': user={EndUserId}")]
+    private static partial void LogMcpToolArgumentParseError(ILogger logger, string toolName, Exception exception, string? endUserId);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "MCP tool skipped during option setup — not on allowlist: tool={ToolName}")]
     private static partial void LogMcpToolSkippedNotAllowed(ILogger logger, string toolName);
 
@@ -546,10 +590,41 @@ public partial class AIChatService
 
     /// <summary>
     /// Returns <c>true</c> when the API error indicates the conversation context window was exceeded.
+    /// Prefers structured JSON error code from the response body; falls back to message text matching.
+    /// Also handles HTTP 413 (payload too large via API gateway) and <c>token_limit_exceeded</c>.
     /// </summary>
-    private static bool IsContextLengthError(ClientResultException ex) =>
-        ex.Status == 400 &&
-        (ex.Message.Contains("context_length_exceeded", StringComparison.OrdinalIgnoreCase) ||
-         ex.Message.Contains("maximum context length", StringComparison.OrdinalIgnoreCase) ||
-         ex.Message.Contains("reduce the length of the messages", StringComparison.OrdinalIgnoreCase));
+    private static bool IsContextLengthError(ClientResultException ex)
+    {
+        if (ex.Status is not (400 or 413)) return false;
+
+        // Prefer structured error code from the response body
+        var errorCode = TryExtractErrorCode(ex);
+        if (errorCode is not null)
+            return errorCode is "context_length_exceeded" or "token_limit_exceeded";
+
+        // Fallback: substring match on exception message (Azure OpenAI format may vary)
+        return ex.Message.Contains("context_length_exceeded", StringComparison.OrdinalIgnoreCase) ||
+               ex.Message.Contains("maximum context length", StringComparison.OrdinalIgnoreCase) ||
+               ex.Message.Contains("reduce the length of the messages", StringComparison.OrdinalIgnoreCase) ||
+               ex.Message.Contains("token_limit_exceeded", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Attempts to extract the <c>error.code</c> field from the raw JSON response body.
+    /// Returns <c>null</c> on any parse failure — this is best-effort.
+    /// </summary>
+    private static string? TryExtractErrorCode(ClientResultException ex)
+    {
+        try
+        {
+            var content = ex.GetRawResponse()?.Content;
+            if (content is null) return null;
+            using var doc = System.Text.Json.JsonDocument.Parse(content.ToMemory());
+            if (doc.RootElement.TryGetProperty("error", out var error) &&
+                error.TryGetProperty("code", out var code))
+                return code.GetString();
+        }
+        catch { /* best-effort — don't let error parsing crash the error handler */ }
+        return null;
+    }
 }

--- a/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using OpenAI.Responses;
+using System.ClientModel;
 using System.Collections.Frozen;
 
 namespace EssentialCSharp.Chat.Common.Services;
@@ -183,6 +184,10 @@ public partial class AIChatService
         string? endUserId = null,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        // Track this leg's response ID so tool-call continuations chain from it,
+        // ensuring the model's context includes the user's message + reasoning.
+        string? currentLegResponseId = null;
+
         await foreach (var update in streamingUpdates.WithCancellation(cancellationToken))
         {
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -190,7 +195,8 @@ public partial class AIChatService
             {
                 // Emit the response ID early so the controller can record ownership
                 // before the stream completes — handles client disconnects mid-stream.
-                yield return (string.Empty, responseId: created.Response.Id);
+                currentLegResponseId = created.Response.Id;
+                yield return (string.Empty, responseId: currentLegResponseId);
             }
             else if (update is StreamingResponseOutputItemDoneUpdate itemDone)
             {
@@ -200,10 +206,13 @@ public partial class AIChatService
                     if (toolCallDepth >= 10)
                         throw new InvalidOperationException("Maximum tool call depth exceeded.");
 
-                    // Execute the function call and stream its response.
-                    // Each nested ProcessStreamingUpdatesAsync emits its own StreamingResponseCreatedUpdate
-                    // (which already yields its responseId early), so no extra tracking is needed here.
-                    await foreach (var functionResult in ExecuteFunctionCallAsync(functionCallItem, responseOptions, mcpClient, toolCallDepth + 1, endUserId, cancellationToken))
+                    // Chain the continuation from THIS leg's response ID so the model sees:
+                    //   context(outer) → userMessage + AI reasoning + funcCall (stored in currentLegResponseId)
+                    //   → [toolOutput only] → next response
+                    // Using the outer previousResponseId here would omit the user's message from context.
+                    var continuationOptions = CloneOptionsWithPreviousResponseId(responseOptions, currentLegResponseId);
+
+                    await foreach (var functionResult in ExecuteFunctionCallAsync(functionCallItem, continuationOptions, mcpClient, toolCallDepth + 1, endUserId, cancellationToken))
                     {
                         yield return functionResult;
                     }
@@ -239,12 +248,11 @@ public partial class AIChatService
         if (!IsMcpToolAllowed(functionCallItem.FunctionName))
         {
             LogMcpToolCallRejected(_Logger, functionCallItem.FunctionName, endUserId);
-            // Feed a benign error back to the model so it can recover gracefully,
-            // mirroring what GetChatCompletionCore does on the non-streaming path.
+            // Feed a benign error back to the model so it can recover gracefully.
+            // The functionCallItem is in the stored response at PreviousResponseId — only send the output.
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             var errorItems = new List<ResponseItem>
             {
-                functionCallItem,
                 new FunctionCallOutputResponseItem(
                     functionCallItem.CallId,
                     $"Tool '{functionCallItem.FunctionName}' is not available.")
@@ -262,32 +270,7 @@ public partial class AIChatService
 
         LogMcpToolCallInvokedStream(_Logger, functionCallItem.FunctionName, toolCallDepth, endUserId);
         // A dictionary of arguments to pass to the tool. Each key represents a parameter name, and its associated value represents the argument value.
-        Dictionary<string, object?> arguments = [];
-        // example JsonResponse:
-        // "{\"question\":\"Azure OpenAI Responses API (Preview)\"}"
-        var jsonResponse = functionCallItem.FunctionArguments.ToString();
-        var jsonArguments = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(jsonResponse) ?? new Dictionary<string, object?>();
-
-        // Convert JsonElement values to their actual types
-        foreach (var kvp in jsonArguments)
-        {
-            if (kvp.Value is System.Text.Json.JsonElement jsonElement)
-            {
-                arguments[kvp.Key] = jsonElement.ValueKind switch
-                {
-                    System.Text.Json.JsonValueKind.String => jsonElement.GetString(),
-                    System.Text.Json.JsonValueKind.Number => jsonElement.GetDecimal(),
-                    System.Text.Json.JsonValueKind.True => true,
-                    System.Text.Json.JsonValueKind.False => false,
-                    System.Text.Json.JsonValueKind.Null => null,
-                    _ => jsonElement.ToString()
-                };
-            }
-            else
-            {
-                arguments[kvp.Key] = kvp.Value;
-            }
-        }
+        var arguments = ParseToolArguments(functionCallItem.FunctionArguments);
 
         // Execute the function call using the MCP client
         var toolResult = await mcpClient.CallToolAsync(
@@ -295,12 +278,11 @@ public partial class AIChatService
             arguments: arguments,
             cancellationToken: cancellationToken);
 
-        // Create input items with both the function call and the result
-        // This matches the Python pattern: append both tool_call and result
+        // The functionCallItem is already stored in the server's context (referenced by
+        // responseOptions.PreviousResponseId). Only the tool output is new content.
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         var inputItems = new List<ResponseItem>
         {
-            functionCallItem, // The original function call
             new FunctionCallOutputResponseItem(functionCallItem.CallId, McpToolResultFormatter.GetModelInput(toolResult))
         };
 #pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -412,15 +394,22 @@ public partial class AIChatService
         // Create the response using the Responses API
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         List<ResponseItem> responseItems = [ResponseItem.CreateUserMessageItem(prompt)];
-#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         const int MaxToolCallIterations = 10;
         for (int iteration = 0; iteration < MaxToolCallIterations; iteration++)
         {
-            var response = await _ResponseClient.CreateResponseAsync(
-                responseItems,
-                options: responseOptions,
-                cancellationToken: cancellationToken);
+            ClientResult<OpenAIResponse> response;
+            try
+            {
+                response = await _ResponseClient.CreateResponseAsync(
+                    responseItems,
+                    options: responseOptions,
+                    cancellationToken: cancellationToken);
+            }
+            catch (ClientResultException ex) when (IsContextLengthError(ex))
+            {
+                throw new ConversationContextLimitExceededException(responseOptions.PreviousResponseId, ex);
+            }
 
             string responseId = response.Value.Id;
 
@@ -429,6 +418,12 @@ public partial class AIChatService
 
             if (functionCalls.Count > 0 && mcpClient != null)
             {
+                // Advance the chain: the server now has everything up to responseId stored
+                // (user message + all prior function calls/results + this response's funcCalls).
+                // The next request only needs to supply the tool outputs — not the growing history.
+                responseOptions.PreviousResponseId = responseId;
+                responseItems = [];
+
                 foreach (var functionCallItem in functionCalls)
                 {
                     // Defense-in-depth: validate tool name against static allowlist before executing.
@@ -436,8 +431,7 @@ public partial class AIChatService
                     if (!IsMcpToolAllowed(functionCallItem.FunctionName))
                     {
                         LogMcpToolCallRejected(_Logger, functionCallItem.FunctionName, endUserId);
-                        // Return a benign error to the model so it can respond gracefully
-                        responseItems.Add(functionCallItem);
+                        // The functionCallItem is in the stored response; send only the error output.
                         responseItems.Add(new FunctionCallOutputResponseItem(
                             functionCallItem.CallId,
                             $"Tool '{functionCallItem.FunctionName}' is not available."));
@@ -445,31 +439,15 @@ public partial class AIChatService
                     }
 
                     LogMcpToolCallInvoked(_Logger, functionCallItem.FunctionName, iteration, endUserId);
-                    var jsonResponse = functionCallItem.FunctionArguments.ToString();
-                    var jsonArguments = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(jsonResponse) ?? new Dictionary<string, object?>();
-
-                    Dictionary<string, object?> arguments = [];
-                    foreach (var kvp in jsonArguments)
-                    {
-                        arguments[kvp.Key] = kvp.Value is System.Text.Json.JsonElement jsonElement
-                            ? jsonElement.ValueKind switch
-                            {
-                                System.Text.Json.JsonValueKind.String => jsonElement.GetString(),
-                                System.Text.Json.JsonValueKind.Number => jsonElement.GetDecimal(),
-                                System.Text.Json.JsonValueKind.True => true,
-                                System.Text.Json.JsonValueKind.False => false,
-                                System.Text.Json.JsonValueKind.Null => null,
-                                _ => (object?)jsonElement.ToString()
-                            }
-                            : kvp.Value;
-                    }
+                    var arguments = ParseToolArguments(functionCallItem.FunctionArguments);
 
                     var toolResult = await mcpClient.CallToolAsync(
                         functionCallItem.FunctionName,
                         arguments: arguments,
                         cancellationToken: cancellationToken);
 
-                    responseItems.Add(functionCallItem);
+                    // The functionCallItem is stored server-side in the response at PreviousResponseId.
+                    // Only the tool output is new content that needs to be included.
                     responseItems.Add(new FunctionCallOutputResponseItem(
                         functionCallItem.CallId,
                         McpToolResultFormatter.GetModelInput(toolResult)));
@@ -501,6 +479,56 @@ public partial class AIChatService
         return _AllowedMcpTools.Contains(toolName);
     }
 
+    /// <summary>
+    /// Returns a shallow clone of <paramref name="source"/> with
+    /// <see cref="ResponseCreationOptions.PreviousResponseId"/> replaced.
+    /// Used when chaining tool-call continuations from a specific response leg.
+    /// </summary>
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private static ResponseCreationOptions CloneOptionsWithPreviousResponseId(
+        ResponseCreationOptions source,
+        string? previousResponseId)
+    {
+        var clone = new ResponseCreationOptions
+        {
+            Instructions = source.Instructions,
+            PreviousResponseId = previousResponseId,
+            ReasoningOptions = source.ReasoningOptions,
+        };
+        foreach (var tool in source.Tools)
+            clone.Tools.Add(tool);
+        return clone;
+    }
+#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+    /// <summary>
+    /// Parses function call arguments from a <see cref="BinaryData"/> JSON payload into a
+    /// strongly-typed dictionary, converting <see cref="System.Text.Json.JsonElement"/> values
+    /// to their native CLR equivalents.
+    /// </summary>
+    private static Dictionary<string, object?> ParseToolArguments(BinaryData functionArguments)
+    {
+        var jsonArguments = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(
+            functionArguments.ToString()) ?? [];
+
+        var arguments = new Dictionary<string, object?>(jsonArguments.Count);
+        foreach (var kvp in jsonArguments)
+        {
+            arguments[kvp.Key] = kvp.Value is System.Text.Json.JsonElement jsonElement
+                ? jsonElement.ValueKind switch
+                {
+                    System.Text.Json.JsonValueKind.String => jsonElement.GetString(),
+                    System.Text.Json.JsonValueKind.Number => jsonElement.GetDecimal(),
+                    System.Text.Json.JsonValueKind.True => true,
+                    System.Text.Json.JsonValueKind.False => false,
+                    System.Text.Json.JsonValueKind.Null => null,
+                    _ => (object?)jsonElement.ToString()
+                }
+                : kvp.Value;
+        }
+        return arguments;
+    }
+
     [LoggerMessage(Level = LogLevel.Information, Message = "AI tool call invoked: tool={ToolName} iteration={Iteration} user={EndUserId}")]
     private static partial void LogMcpToolCallInvoked(ILogger logger, string toolName, int iteration, string? endUserId);
 
@@ -515,4 +543,13 @@ public partial class AIChatService
 
     [LoggerMessage(Level = LogLevel.Information, Message = "AI contextual search performed for prompt enrichment")]
     private static partial void LogContextualSearchPerformed(ILogger logger);
+
+    /// <summary>
+    /// Returns <c>true</c> when the API error indicates the conversation context window was exceeded.
+    /// </summary>
+    private static bool IsContextLengthError(ClientResultException ex) =>
+        ex.Status == 400 &&
+        (ex.Message.Contains("context_length_exceeded", StringComparison.OrdinalIgnoreCase) ||
+         ex.Message.Contains("maximum context length", StringComparison.OrdinalIgnoreCase) ||
+         ex.Message.Contains("reduce the length of the messages", StringComparison.OrdinalIgnoreCase));
 }

--- a/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
@@ -648,7 +648,12 @@ public partial class AIChatService
                 error.TryGetProperty("code", out var code))
                 return code.GetString();
         }
-        catch { /* best-effort — don't let error parsing crash the error handler */ }
+        catch (Exception)
+        {
+            // Best-effort extraction inside an error handler — catch all to guarantee we never
+            // throw from error-parsing logic. The Azure SDK response internals are outside our
+            // control and the exception surface can change across SDK versions.
+        }
         return null;
     }
 }

--- a/EssentialCSharp.Chat.Shared/Services/ConversationContextLimitExceededException.cs
+++ b/EssentialCSharp.Chat.Shared/Services/ConversationContextLimitExceededException.cs
@@ -1,0 +1,30 @@
+namespace EssentialCSharp.Chat.Common.Services;
+
+/// <summary>
+/// Thrown when a conversation's accumulated context exceeds the model's context window limit.
+/// </summary>
+/// <remarks>
+/// This occurs when using <c>previous_response_id</c> chaining over many turns — the server
+/// reconstructs the full history on each request, and that history eventually exceeds the model's
+/// maximum input tokens. Callers should prompt the user to start a new conversation rather than
+/// retrying with the same <c>previousResponseId</c>.
+/// </remarks>
+public sealed class ConversationContextLimitExceededException : Exception
+{
+    /// <summary>
+    /// The <c>previous_response_id</c> that caused the overflow, if known.
+    /// </summary>
+    public string? PreviousResponseId { get; }
+
+    public ConversationContextLimitExceededException(string? previousResponseId)
+        : base("This conversation has exceeded the model's context window limit.")
+    {
+        PreviousResponseId = previousResponseId;
+    }
+
+    public ConversationContextLimitExceededException(string? previousResponseId, Exception innerException)
+        : base("This conversation has exceeded the model's context window limit.", innerException)
+    {
+        PreviousResponseId = previousResponseId;
+    }
+}

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -151,7 +151,13 @@ public partial class ChatController : ControllerBase
                 await Response.WriteAsync("data: {\"type\":\"error\",\"message\":\"This conversation has grown too long. Please start a new one.\",\"errorCode\":\"context_limit_exceeded\"}\n\n", CancellationToken.None);
                 await Response.Body.FlushAsync(CancellationToken.None);
             }
-            catch { /* client already disconnected */ }
+            catch (Exception)
+            {
+                // Best-effort write to an already-streaming response. Kestrel can throw
+                // IOException (connection reset), OperationCanceledException, or
+                // ObjectDisposedException on abrupt client disconnect — swallow all to
+                // avoid masking the original exception.
+            }
         }
         catch (Exception ex) when (!Response.HasStarted)
         {
@@ -168,7 +174,13 @@ public partial class ChatController : ControllerBase
                 await Response.WriteAsync("data: {\"type\":\"error\",\"message\":\"Stream interrupted\"}\n\n", CancellationToken.None);
                 await Response.Body.FlushAsync(CancellationToken.None);
             }
-            catch { /* client already disconnected */ }
+            catch (Exception)
+            {
+                // Best-effort write to an already-streaming response. Kestrel can throw
+                // IOException (connection reset), OperationCanceledException, or
+                // ObjectDisposedException on abrupt client disconnect — swallow all to
+                // avoid masking the original exception.
+            }
         }
     }
 

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -143,9 +143,9 @@ public partial class ChatController : ControllerBase
             Response.ContentType = "application/json";
             await Response.WriteAsJsonAsync(new { error = "This conversation has grown too long. Please start a new one.", errorCode = "context_limit_exceeded" }, CancellationToken.None);
         }
-        catch (ConversationContextLimitExceededException)
+        catch (ConversationContextLimitExceededException ex)
         {
-            LogChatStreamErrorMidStream(_Logger, new InvalidOperationException("Context limit exceeded mid-stream"), User.Identity?.Name);
+            LogChatStreamErrorMidStream(_Logger, ex, User.Identity?.Name);
             try
             {
                 await Response.WriteAsync("data: {\"type\":\"error\",\"message\":\"This conversation has grown too long. Please start a new one.\",\"errorCode\":\"context_limit_exceeded\"}\n\n", CancellationToken.None);

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -44,21 +44,28 @@ public partial class ChatController : ControllerBase
         if (!_ResponseIdValidationService.ValidateResponseId(userId, previousResponseId))
             return BadRequest(new { error = "Invalid conversation context." });
 
-        var (response, responseId) = await _AiChatService.GetChatCompletion(
-            prompt: request.Message,
-            previousResponseId: previousResponseId,
-            enableContextualSearch: request.EnableContextualSearch,
-            endUserId: userId,
-            cancellationToken: cancellationToken);
-
-        _ResponseIdValidationService.RecordResponseId(userId, responseId);
-
-        return Ok(new ChatMessageResponse
+        try
         {
-            Response = response,
-            ResponseId = responseId,
-            Timestamp = DateTime.UtcNow
-        });
+            var (response, responseId) = await _AiChatService.GetChatCompletion(
+                prompt: request.Message,
+                previousResponseId: previousResponseId,
+                enableContextualSearch: request.EnableContextualSearch,
+                endUserId: userId,
+                cancellationToken: cancellationToken);
+
+            _ResponseIdValidationService.RecordResponseId(userId, responseId);
+
+            return Ok(new ChatMessageResponse
+            {
+                Response = response,
+                ResponseId = responseId,
+                Timestamp = DateTime.UtcNow
+            });
+        }
+        catch (ConversationContextLimitExceededException)
+        {
+            return BadRequest(new { error = "This conversation has grown too long. Please start a new one.", errorCode = "context_limit_exceeded" });
+        }
     }
 
     [HttpPost("stream")]
@@ -129,6 +136,22 @@ public partial class ChatController : ControllerBase
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested || HttpContext.RequestAborted.IsCancellationRequested)
         {
             LogChatStreamCancelled(_Logger, User.Identity?.Name);
+        }
+        catch (ConversationContextLimitExceededException) when (!Response.HasStarted)
+        {
+            Response.StatusCode = 400;
+            Response.ContentType = "application/json";
+            await Response.WriteAsJsonAsync(new { error = "This conversation has grown too long. Please start a new one.", errorCode = "context_limit_exceeded" }, CancellationToken.None);
+        }
+        catch (ConversationContextLimitExceededException)
+        {
+            LogChatStreamErrorMidStream(_Logger, new InvalidOperationException("Context limit exceeded mid-stream"), User.Identity?.Name);
+            try
+            {
+                await Response.WriteAsync("data: {\"type\":\"error\",\"message\":\"This conversation has grown too long. Please start a new one.\",\"errorCode\":\"context_limit_exceeded\"}\n\n", CancellationToken.None);
+                await Response.Body.FlushAsync(CancellationToken.None);
+            }
+            catch { /* client already disconnected */ }
         }
         catch (Exception ex) when (!Response.HasStarted)
         {


### PR DESCRIPTION
## Summary

Three rounds of review against the [Azure OpenAI Responses API docs](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/responses) (using Claude Opus 4.6 and GPT-5.5 as parallel review subagents) identified and fixed several correctness bugs and robustness gaps in the AI chat implementation.

---

## Critical fixes

### C1 — Parallel streaming tool calls created forked conversation branches

Previously, `ProcessStreamingUpdatesAsync` fired a separate API continuation per tool call inline during the stream. With N parallel tool calls this created N independent conversation branches — each continuation only saw its own tool result, not the others.

**Fix:** Two-phase pattern — buffer all `FunctionCallResponseItem`s during the stream, execute them sequentially after the stream completes, then make **one** continuation with all outputs. Matches the non-streaming behavior.

### C2 — Context length errors not caught in streaming path

`ClientResultException` from a context-window overflow propagates through `await foreach` but C# prohibits `yield return` inside a `try/catch` block (CS1626).

**Fix:** Added `RethrowContextLengthErrors` helper that puts `try/catch` only around `MoveNextAsync`, with `yield return` outside — the only CS1626-safe pattern for exception remapping in async iterators.

---

## High fixes

### H1 — SSE error event lost on mid-stream exception

The second `catch (Exception ex)` block in `StreamMessage` was missing its `try { await Response.WriteAsync(...) } catch {}` body, so clients received no signal when the stream was interrupted.

### H2 — `CloneOptionsWithPreviousResponseId` copied only 3 of 14 fields

Tool-call continuation legs inherited `Instructions`, `PreviousResponseId`, and `Tools` — but not `EndUserId`, `Temperature`, `TopP`, `TruncationMode`, `MaxOutputTokenCount`, `TextOptions`, `ParallelToolCallsEnabled`, `StoredOutputEnabled`, `ToolChoice`, `ServiceTier`, or `Metadata`. Continuations were silently using defaults for all of those.

### H3 — Context length detection relied on substring matching only

**Fix:** `IsContextLengthError` now parses the structured JSON error body via `TryExtractErrorCode` and checks the `error.code` field first (`context_length_exceeded`, `token_limit_exceeded`). Also handles HTTP 413. Falls back to message substring matching.

---

## Medium fixes (from second review pass)

- **`ParseToolArguments` unguarded in non-streaming path** — a `JsonException` on malformed model-generated arguments would bubble up as a 500. Now caught identically to the streaming path, returning an error `FunctionCallOutputResponseItem` so the model can recover.
- **`strictModeEnabled: false` for MCP tool registration** — the MCP .NET SDK generates schemas that don't satisfy OpenAI strict-mode constraints (optional params not in `required`, no `additionalProperties: false`, nullable union types). A single non-conforming schema with `strictModeEnabled: true` causes a 400 that blocks all tools.
- **`currentLegResponseId` null guard** — if the API never emits `StreamingResponseCreatedUpdate`, the continuation would fire with `PreviousResponseId = null`, causing a confusing 400. Now throws `InvalidOperationException` with a diagnostic message.
- **Log original exception in mid-stream context-limit handler** — was logging a freshly constructed `InvalidOperationException`, discarding the original stack trace and `PreviousResponseId`.

---

## Bonus

- **`EndUserId` wired up** — `CreateResponseOptionsAsync` now sets `options.EndUserId` (the SDK exposes it; the previous code discarded it). Enables Azure OpenAI abuse monitoring and Defender prompt-shield correlation.
- **`LogMcpToolArgumentParseError`** logger message added.
- **`ConversationContextLimitExceededException`** domain exception with `PreviousResponseId` property.

---

## Files changed

| File | Changes |
|------|---------|
| `EssentialCSharp.Chat.Shared/Services/AIChatService.cs` | All service-level fixes |
| `EssentialCSharp.Chat.Shared/Services/ConversationContextLimitExceededException.cs` | New domain exception |
| `EssentialCSharp.Web/Controllers/ChatController.cs` | Context-limit handling, SSE error write, logging |
