### PR TITLE
fix: remove redundant --registry flag from az acr import

### DIFF
--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -189,7 +189,6 @@ jobs:
           az acr import \
             --name "${PROD_ACR%.azurecr.io}" \
             --source "${DEV_ACR}/essentialcsharpweb:${{ github.sha }}" \
-            --registry "${DEV_ACR%.azurecr.io}" \
             --image "essentialcsharpweb:${{ github.sha }}" \
             --image "essentialcsharpweb:latest" \
             --force


### PR DESCRIPTION
## Problem

`az acr import` was being called with both `--source <registry>/<image>:<tag>` (which includes the full hostname) **and** `--registry <name>`, causing this warning on every prod deploy:

```
WARNING: The login server name of "ecsdevacr.azurecr.io" in the "--source" argument will be ignored as "--registry" already supplies the same information
```

`--registry` is only needed when `--source` omits the registry hostname. Since our `--source` already contains the full `azurecr.io` hostname, `--registry` is redundant.

## Fix

Drop the `--registry` flag from the `az acr import` call in `deploy-production`.