### PR TITLE
tests: migrate integration tests to TUnit.AspNetCore WebApplicationTest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
     <PackageVersion Include="TUnit" Version="1.40.5" />
+    <PackageVersion Include="TUnit.AspNetCore" Version="1.40.5" />
     <PackageVersion Include="EssentialCSharp.Shared.Models" Version="$(ToolingPackagesVersion)" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="IntelliTect.Multitool" Version="2.0.0" />

--- a/EssentialCSharp.Web.Tests/ContentRateLimitingTests.cs
+++ b/EssentialCSharp.Web.Tests/ContentRateLimitingTests.cs
@@ -12,7 +12,7 @@ public class ContentRateLimitingTests : IntegrationTestBase
     [Test]
     public async Task ContentEndpoint_ExceedingPerMinuteLimit_Returns429()
     {
-        HttpClient client = Factory.CreateClient();
+        using HttpClient client = CreateClientWithoutRedirectFollowing();
 
         // Anonymous limit is 10/min. First 10 requests should not be rate-limited.
         for (int i = 0; i < 10; i++)

--- a/EssentialCSharp.Web.Tests/ContentRateLimitingTests.cs
+++ b/EssentialCSharp.Web.Tests/ContentRateLimitingTests.cs
@@ -5,17 +5,15 @@ namespace EssentialCSharp.Web.Tests;
 
 /// <summary>
 /// HTTP integration tests for the "content" rate limit policy.
-/// Uses its own factory (PerClass) to get a fresh in-memory rate limiter for each run.
+/// Each test gets its own factory (fresh IHost) so the rate limiter starts from a clean state.
 /// Anonymous users are limited to 10 requests per minute on chapter content pages.
 /// </summary>
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class ContentRateLimitingTests(WebApplicationFactory factory)
+public class ContentRateLimitingTests : IntegrationTestBase
 {
     [Test]
     public async Task ContentEndpoint_ExceedingPerMinuteLimit_Returns429()
     {
-        // AllowAutoRedirect = false prevents redirect-following from consuming extra permits.
-        HttpClient client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        HttpClient client = Factory.Inner.CreateClient(new WebApplicationFactoryClientOptions
         {
             AllowAutoRedirect = false
         });

--- a/EssentialCSharp.Web.Tests/ContentRateLimitingTests.cs
+++ b/EssentialCSharp.Web.Tests/ContentRateLimitingTests.cs
@@ -12,7 +12,7 @@ public class ContentRateLimitingTests : IntegrationTestBase
     [Test]
     public async Task ContentEndpoint_ExceedingPerMinuteLimit_Returns429()
     {
-        using HttpClient client = CreateClientWithoutRedirectFollowing();
+        using HttpClient client = CreateClientWithoutAutoRedirect();
 
         // Anonymous limit is 10/min. First 10 requests should not be rate-limited.
         for (int i = 0; i < 10; i++)

--- a/EssentialCSharp.Web.Tests/ContentRateLimitingTests.cs
+++ b/EssentialCSharp.Web.Tests/ContentRateLimitingTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace EssentialCSharp.Web.Tests;
 
@@ -13,10 +12,7 @@ public class ContentRateLimitingTests : IntegrationTestBase
     [Test]
     public async Task ContentEndpoint_ExceedingPerMinuteLimit_Returns429()
     {
-        HttpClient client = Factory.Inner.CreateClient(new WebApplicationFactoryClientOptions
-        {
-            AllowAutoRedirect = false
-        });
+        HttpClient client = Factory.CreateClient();
 
         // Anonymous limit is 10/min. First 10 requests should not be rate-limited.
         for (int i = 0; i < 10; i++)

--- a/EssentialCSharp.Web.Tests/EssentialCSharp.Web.Tests.csproj
+++ b/EssentialCSharp.Web.Tests/EssentialCSharp.Web.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Moq.AutoMock" />
     <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit.AspNetCore" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/EssentialCSharp.Web.Tests/FunctionalTests.cs
+++ b/EssentialCSharp.Web.Tests/FunctionalTests.cs
@@ -13,7 +13,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/alive")]
     public async Task WhenTheApplicationStarts_ItCanLoadLoadPages(string relativeUrl)
     {
-        HttpClient client = Factory.CreateClient();
+        HttpClient client = Factory.Inner.CreateClient();
         using HttpResponseMessage response = await client.GetAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -29,7 +29,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/about?someOtherParam=value")]
     public async Task WhenPagesAreAccessed_TheyReturnHtml(string relativeUrl)
     {
-        HttpClient client = Factory.CreateClient();
+        HttpClient client = Factory.Inner.CreateClient();
         using HttpResponseMessage response = await client.GetAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -45,7 +45,7 @@ public class FunctionalTests : IntegrationTestBase
     [Test]
     public async Task WhenTheApplicationStarts_NonExistingPage_GivesCorrectStatusCode()
     {
-        HttpClient client = Factory.CreateClient();
+        HttpClient client = Factory.Inner.CreateClient();
         using HttpResponseMessage response = await client.GetAsync("/non-existing-page1234");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);

--- a/EssentialCSharp.Web.Tests/FunctionalTests.cs
+++ b/EssentialCSharp.Web.Tests/FunctionalTests.cs
@@ -2,9 +2,7 @@ using System.Net;
 
 namespace EssentialCSharp.Web.Tests;
 
-[NotInParallel("FunctionalTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class FunctionalTests(WebApplicationFactory factory)
+public class FunctionalTests : IntegrationTestBase
 {
     [Test]
     [Arguments("/")]
@@ -15,7 +13,7 @@ public class FunctionalTests(WebApplicationFactory factory)
     [Arguments("/alive")]
     public async Task WhenTheApplicationStarts_ItCanLoadLoadPages(string relativeUrl)
     {
-        HttpClient client = factory.CreateClient();
+        HttpClient client = Factory.CreateClient();
         using HttpResponseMessage response = await client.GetAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -31,7 +29,7 @@ public class FunctionalTests(WebApplicationFactory factory)
     [Arguments("/about?someOtherParam=value")]
     public async Task WhenPagesAreAccessed_TheyReturnHtml(string relativeUrl)
     {
-        HttpClient client = factory.CreateClient();
+        HttpClient client = Factory.CreateClient();
         using HttpResponseMessage response = await client.GetAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -47,7 +45,7 @@ public class FunctionalTests(WebApplicationFactory factory)
     [Test]
     public async Task WhenTheApplicationStarts_NonExistingPage_GivesCorrectStatusCode()
     {
-        HttpClient client = factory.CreateClient();
+        HttpClient client = Factory.CreateClient();
         using HttpResponseMessage response = await client.GetAsync("/non-existing-page1234");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);

--- a/EssentialCSharp.Web.Tests/FunctionalTests.cs
+++ b/EssentialCSharp.Web.Tests/FunctionalTests.cs
@@ -13,8 +13,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/alive")]
     public async Task WhenTheApplicationStarts_ItCanLoadLoadPages(string relativeUrl)
     {
-        HttpClient client = CreateRedirectFollowingClient();
-        using HttpResponseMessage response = await client.GetAsync(relativeUrl);
+        using HttpResponseMessage response = await GetWithRedirectsAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -29,8 +28,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/about?someOtherParam=value")]
     public async Task WhenPagesAreAccessed_TheyReturnHtml(string relativeUrl)
     {
-        HttpClient client = CreateRedirectFollowingClient();
-        using HttpResponseMessage response = await client.GetAsync(relativeUrl);
+        using HttpResponseMessage response = await GetWithRedirectsAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
 
@@ -45,8 +43,7 @@ public class FunctionalTests : IntegrationTestBase
     [Test]
     public async Task WhenTheApplicationStarts_NonExistingPage_GivesCorrectStatusCode()
     {
-        HttpClient client = CreateRedirectFollowingClient();
-        using HttpResponseMessage response = await client.GetAsync("/non-existing-page1234");
+        using HttpResponseMessage response = await GetWithRedirectsAsync("/non-existing-page1234");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
     }

--- a/EssentialCSharp.Web.Tests/FunctionalTests.cs
+++ b/EssentialCSharp.Web.Tests/FunctionalTests.cs
@@ -13,7 +13,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/alive")]
     public async Task WhenTheApplicationStarts_ItCanLoadLoadPages(string relativeUrl)
     {
-        using HttpClient client = Factory.CreateClient();
+        using HttpClient client = CreateClientWithoutAutoRedirect();
         using HttpResponseMessage response = await GetFollowingGetRedirectsAsync(client, relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -29,7 +29,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/about?someOtherParam=value")]
     public async Task WhenPagesAreAccessed_TheyReturnHtml(string relativeUrl)
     {
-        using HttpClient client = Factory.CreateClient();
+        using HttpClient client = CreateClientWithoutAutoRedirect();
         using HttpResponseMessage response = await GetFollowingGetRedirectsAsync(client, relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -45,7 +45,7 @@ public class FunctionalTests : IntegrationTestBase
     [Test]
     public async Task WhenTheApplicationStarts_NonExistingPage_GivesCorrectStatusCode()
     {
-        using HttpClient client = Factory.CreateClient();
+        using HttpClient client = CreateClientWithoutAutoRedirect();
         using HttpResponseMessage response = await GetFollowingGetRedirectsAsync(client, "/non-existing-page1234");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);

--- a/EssentialCSharp.Web.Tests/FunctionalTests.cs
+++ b/EssentialCSharp.Web.Tests/FunctionalTests.cs
@@ -13,7 +13,8 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/alive")]
     public async Task WhenTheApplicationStarts_ItCanLoadLoadPages(string relativeUrl)
     {
-        using HttpResponseMessage response = await GetFollowingRedirectsAsync(relativeUrl);
+        using HttpClient client = Factory.CreateClient();
+        using HttpResponseMessage response = await GetFollowingGetRedirectsAsync(client, relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -28,7 +29,8 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/about?someOtherParam=value")]
     public async Task WhenPagesAreAccessed_TheyReturnHtml(string relativeUrl)
     {
-        using HttpResponseMessage response = await GetFollowingRedirectsAsync(relativeUrl);
+        using HttpClient client = Factory.CreateClient();
+        using HttpResponseMessage response = await GetFollowingGetRedirectsAsync(client, relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
 
@@ -43,7 +45,8 @@ public class FunctionalTests : IntegrationTestBase
     [Test]
     public async Task WhenTheApplicationStarts_NonExistingPage_GivesCorrectStatusCode()
     {
-        using HttpResponseMessage response = await GetFollowingRedirectsAsync("/non-existing-page1234");
+        using HttpClient client = Factory.CreateClient();
+        using HttpResponseMessage response = await GetFollowingGetRedirectsAsync(client, "/non-existing-page1234");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
     }

--- a/EssentialCSharp.Web.Tests/FunctionalTests.cs
+++ b/EssentialCSharp.Web.Tests/FunctionalTests.cs
@@ -13,7 +13,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/alive")]
     public async Task WhenTheApplicationStarts_ItCanLoadLoadPages(string relativeUrl)
     {
-        HttpClient client = Factory.Inner.CreateClient();
+        HttpClient client = CreateRedirectFollowingClient();
         using HttpResponseMessage response = await client.GetAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -29,7 +29,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/about?someOtherParam=value")]
     public async Task WhenPagesAreAccessed_TheyReturnHtml(string relativeUrl)
     {
-        HttpClient client = Factory.Inner.CreateClient();
+        HttpClient client = CreateRedirectFollowingClient();
         using HttpResponseMessage response = await client.GetAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
@@ -45,7 +45,7 @@ public class FunctionalTests : IntegrationTestBase
     [Test]
     public async Task WhenTheApplicationStarts_NonExistingPage_GivesCorrectStatusCode()
     {
-        HttpClient client = Factory.Inner.CreateClient();
+        HttpClient client = CreateRedirectFollowingClient();
         using HttpResponseMessage response = await client.GetAsync("/non-existing-page1234");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);

--- a/EssentialCSharp.Web.Tests/FunctionalTests.cs
+++ b/EssentialCSharp.Web.Tests/FunctionalTests.cs
@@ -13,7 +13,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/alive")]
     public async Task WhenTheApplicationStarts_ItCanLoadLoadPages(string relativeUrl)
     {
-        using HttpResponseMessage response = await GetWithRedirectsAsync(relativeUrl);
+        using HttpResponseMessage response = await GetFollowingRedirectsAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -28,7 +28,7 @@ public class FunctionalTests : IntegrationTestBase
     [Arguments("/about?someOtherParam=value")]
     public async Task WhenPagesAreAccessed_TheyReturnHtml(string relativeUrl)
     {
-        using HttpResponseMessage response = await GetWithRedirectsAsync(relativeUrl);
+        using HttpResponseMessage response = await GetFollowingRedirectsAsync(relativeUrl);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
 
@@ -43,7 +43,7 @@ public class FunctionalTests : IntegrationTestBase
     [Test]
     public async Task WhenTheApplicationStarts_NonExistingPage_GivesCorrectStatusCode()
     {
-        using HttpResponseMessage response = await GetWithRedirectsAsync("/non-existing-page1234");
+        using HttpResponseMessage response = await GetFollowingRedirectsAsync("/non-existing-page1234");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
     }

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -8,11 +8,11 @@ namespace EssentialCSharp.Web.Tests;
 public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFactory, Program>
 {
     /// <summary>
-    /// Executes a GET request and follows redirect responses while preserving
-    /// TUnit trace correlation by using <see cref="TracedWebApplicationFactory{T}.CreateClient()"/>.
-    /// This helper intentionally follows redirects using GET requests only.
+    /// Creates an <see cref="HttpClient"/> with <c>AllowAutoRedirect = false</c> so callers can
+    /// assert exact redirect status codes and <c>Location</c> headers without the client
+    /// silently following them.
     /// </summary>
-    protected HttpClient CreateClientWithoutRedirectFollowing() =>
+    protected HttpClient CreateClientWithoutAutoRedirect() =>
         Factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
     protected static async Task<HttpResponseMessage> GetFollowingGetRedirectsAsync(

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -43,6 +43,7 @@ public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFac
 
         if (IsRedirectStatusCode(response.StatusCode))
         {
+            response.Dispose();
             throw new InvalidOperationException(
                 $"Exceeded redirect limit ({maxRedirects}) for '{relativeUrl}'. Last status: {(int)response.StatusCode} {response.StatusCode}.");
         }

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -13,8 +13,12 @@ public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFac
     /// silently following them.
     /// </summary>
     protected HttpClient CreateClientWithoutAutoRedirect() =>
-        Factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        Factory.CreateClient();
 
+    /// <summary>
+    /// Executes an initial GET and follows redirect responses with subsequent GET requests.
+    /// This helper is intentionally GET-only.
+    /// </summary>
     protected static async Task<HttpResponseMessage> GetFollowingGetRedirectsAsync(
         HttpClient client,
         string relativeUrl,
@@ -53,25 +57,25 @@ public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFac
         statusCode == HttpStatusCode.TemporaryRedirect ||
         statusCode == HttpStatusCode.PermanentRedirect;
 
-    public T InServiceScope<T>(Func<IServiceProvider, T> action)
+    protected T InServiceScope<T>(Func<IServiceProvider, T> action)
     {
         using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
         return action(scope.ServiceProvider);
     }
 
-    public void InServiceScope(Action<IServiceProvider> action)
+    protected void InServiceScope(Action<IServiceProvider> action)
     {
         using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
         action(scope.ServiceProvider);
     }
 
-    public async Task<T> InServiceScopeAsync<T>(Func<IServiceProvider, Task<T>> action)
+    protected async Task<T> InServiceScopeAsync<T>(Func<IServiceProvider, Task<T>> action)
     {
         using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
         return await action(scope.ServiceProvider);
     }
 
-    public async Task InServiceScopeAsync(Func<IServiceProvider, Task> action)
+    protected async Task InServiceScopeAsync(Func<IServiceProvider, Task> action)
     {
         using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
         await action(scope.ServiceProvider);

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -13,7 +13,7 @@ public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFac
     /// silently following them.
     /// </summary>
     protected HttpClient CreateClientWithoutAutoRedirect() =>
-        Factory.CreateClient();
+        Factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
     /// <summary>
     /// Executes an initial GET and follows redirect responses with subsequent GET requests.

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using TUnit.AspNetCore;
 
@@ -5,6 +6,16 @@ namespace EssentialCSharp.Web.Tests;
 
 public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFactory, Program>
 {
+    /// <summary>
+    /// Creates an HTTP client with redirect following enabled.
+    /// NOTE: This bypasses TUnit trace correlation because <see cref="TracedWebApplicationFactory{T}"/>
+    /// does not expose a <c>CreateClient(WebApplicationFactoryClientOptions)</c> overload.
+    /// Use <see cref="TUnit.AspNetCore.TracedWebApplicationFactory{T}.CreateClient()"/> for all
+    /// other tests where AllowAutoRedirect=false is acceptable.
+    /// </summary>
+    protected HttpClient CreateRedirectFollowingClient() =>
+        Factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = true });
+
     public T InServiceScope<T>(Func<IServiceProvider, T> action)
     {
         using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
@@ -15,5 +26,17 @@ public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFac
     {
         using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
         action(scope.ServiceProvider);
+    }
+
+    public async Task<T> InServiceScopeAsync<T>(Func<IServiceProvider, Task<T>> action)
+    {
+        using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        return await action(scope.ServiceProvider);
+    }
+
+    public async Task InServiceScopeAsync(Func<IServiceProvider, Task> action)
+    {
+        using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        await action(scope.ServiceProvider);
     }
 }

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using TUnit.AspNetCore;
 
@@ -7,14 +7,38 @@ namespace EssentialCSharp.Web.Tests;
 public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFactory, Program>
 {
     /// <summary>
-    /// Creates an HTTP client with redirect following enabled.
-    /// NOTE: This bypasses TUnit trace correlation because <see cref="TracedWebApplicationFactory{T}"/>
-    /// does not expose a <c>CreateClient(WebApplicationFactoryClientOptions)</c> overload.
-    /// Use <see cref="TUnit.AspNetCore.TracedWebApplicationFactory{T}.CreateClient()"/> for all
-    /// other tests where AllowAutoRedirect=false is acceptable.
+    /// Executes a GET request and follows redirect responses while preserving
+    /// TUnit trace correlation by using <see cref="TracedWebApplicationFactory{T}.CreateClient()"/>.
     /// </summary>
-    protected HttpClient CreateRedirectFollowingClient() =>
-        Factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = true });
+    protected async Task<HttpResponseMessage> GetWithRedirectsAsync(string relativeUrl, int maxRedirects = 10)
+    {
+        HttpClient client = Factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(relativeUrl);
+
+        for (int redirectCount = 0;
+             redirectCount < maxRedirects && IsRedirectStatusCode(response.StatusCode);
+             redirectCount++)
+        {
+            Uri? location = response.Headers.Location;
+            if (location is null)
+            {
+                return response;
+            }
+
+            response.Dispose();
+
+            response = await client.GetAsync(location);
+        }
+
+        return response;
+    }
+
+    private static bool IsRedirectStatusCode(HttpStatusCode statusCode) =>
+        statusCode == HttpStatusCode.Moved ||
+        statusCode == HttpStatusCode.Found ||
+        statusCode == HttpStatusCode.RedirectMethod ||
+        statusCode == HttpStatusCode.TemporaryRedirect ||
+        statusCode == HttpStatusCode.PermanentRedirect;
 
     public T InServiceScope<T>(Func<IServiceProvider, T> action)
     {

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using TUnit.AspNetCore;
+
+namespace EssentialCSharp.Web.Tests;
+
+public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFactory, Program>
+{
+    public T InServiceScope<T>(Func<IServiceProvider, T> action)
+    {
+        using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        return action(scope.ServiceProvider);
+    }
+
+    public void InServiceScope(Action<IServiceProvider> action)
+    {
+        using IServiceScope scope = Factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        action(scope.ServiceProvider);
+    }
+}

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -9,8 +9,9 @@ public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFac
     /// <summary>
     /// Executes a GET request and follows redirect responses while preserving
     /// TUnit trace correlation by using <see cref="TracedWebApplicationFactory{T}.CreateClient()"/>.
+    /// This helper intentionally follows redirects using GET requests only.
     /// </summary>
-    protected async Task<HttpResponseMessage> GetWithRedirectsAsync(string relativeUrl, int maxRedirects = 10)
+    protected async Task<HttpResponseMessage> GetFollowingRedirectsAsync(string relativeUrl, int maxRedirects = 10)
     {
         HttpClient client = Factory.CreateClient();
         HttpResponseMessage response = await client.GetAsync(relativeUrl);
@@ -28,6 +29,12 @@ public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFac
             response.Dispose();
 
             response = await client.GetAsync(location);
+        }
+
+        if (IsRedirectStatusCode(response.StatusCode))
+        {
+            throw new InvalidOperationException(
+                $"Exceeded redirect limit ({maxRedirects}) for '{relativeUrl}'. Last status: {(int)response.StatusCode} {response.StatusCode}.");
         }
 
         return response;

--- a/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
+++ b/EssentialCSharp.Web.Tests/IntegrationTestBase.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using TUnit.AspNetCore;
 
@@ -11,9 +12,14 @@ public abstract class IntegrationTestBase : WebApplicationTest<WebApplicationFac
     /// TUnit trace correlation by using <see cref="TracedWebApplicationFactory{T}.CreateClient()"/>.
     /// This helper intentionally follows redirects using GET requests only.
     /// </summary>
-    protected async Task<HttpResponseMessage> GetFollowingRedirectsAsync(string relativeUrl, int maxRedirects = 10)
+    protected HttpClient CreateClientWithoutRedirectFollowing() =>
+        Factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+    protected static async Task<HttpResponseMessage> GetFollowingGetRedirectsAsync(
+        HttpClient client,
+        string relativeUrl,
+        int maxRedirects = 10)
     {
-        HttpClient client = Factory.CreateClient();
         HttpResponseMessage response = await client.GetAsync(relativeUrl);
 
         for (int redirectCount = 0;

--- a/EssentialCSharp.Web.Tests/ListingSourceCodeControllerTests.cs
+++ b/EssentialCSharp.Web.Tests/ListingSourceCodeControllerTests.cs
@@ -4,14 +4,13 @@ using EssentialCSharp.Web.Models;
 
 namespace EssentialCSharp.Web.Tests;
 
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class ListingSourceCodeControllerTests(WebApplicationFactory factory)
+public class ListingSourceCodeControllerTests : IntegrationTestBase
 {
     [Test]
     public async Task GetListing_WithValidChapterAndListing_Returns200WithContent()
     {
         // Arrange
-        HttpClient client = factory.CreateClient();
+        HttpClient client = Factory.CreateClient();
 
         // Act
         using HttpResponseMessage response = await client.GetAsync("/api/ListingSourceCode/chapter/1/listing/1");
@@ -35,7 +34,7 @@ public class ListingSourceCodeControllerTests(WebApplicationFactory factory)
     public async Task GetListing_WithInvalidChapter_Returns404()
     {
         // Arrange
-        HttpClient client = factory.CreateClient();
+        HttpClient client = Factory.CreateClient();
 
         // Act
         using HttpResponseMessage response = await client.GetAsync("/api/ListingSourceCode/chapter/999/listing/1");
@@ -48,7 +47,7 @@ public class ListingSourceCodeControllerTests(WebApplicationFactory factory)
     public async Task GetListing_WithInvalidListing_Returns404()
     {
         // Arrange
-        HttpClient client = factory.CreateClient();
+        HttpClient client = Factory.CreateClient();
 
         // Act
         using HttpResponseMessage response = await client.GetAsync("/api/ListingSourceCode/chapter/1/listing/999");
@@ -61,7 +60,7 @@ public class ListingSourceCodeControllerTests(WebApplicationFactory factory)
     public async Task GetListingsByChapter_WithValidChapter_ReturnsMultipleListings()
     {
         // Arrange
-        HttpClient client = factory.CreateClient();
+        HttpClient client = Factory.CreateClient();
 
         // Act
         using HttpResponseMessage response = await client.GetAsync("/api/ListingSourceCode/chapter/1");
@@ -92,7 +91,7 @@ public class ListingSourceCodeControllerTests(WebApplicationFactory factory)
     public async Task GetListingsByChapter_WithInvalidChapter_ReturnsEmptyList()
     {
         // Arrange
-        HttpClient client = factory.CreateClient();
+        HttpClient client = Factory.CreateClient();
 
         // Act
         using HttpResponseMessage response = await client.GetAsync("/api/ListingSourceCode/chapter/999");

--- a/EssentialCSharp.Web.Tests/McpApiTokenServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/McpApiTokenServiceTests.cs
@@ -1,13 +1,10 @@
 using EssentialCSharp.Web.Models;
 using EssentialCSharp.Web.Services;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EssentialCSharp.Web.Tests;
 
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpApiTokenServiceTests(WebApplicationFactory factory)
+public class McpApiTokenServiceTests : IntegrationTestBase
 {
     private readonly List<IServiceScope> _scopes = [];
 
@@ -21,8 +18,8 @@ public class McpApiTokenServiceTests(WebApplicationFactory factory)
 
     private async Task<(string UserId, McpApiTokenService TokenService)> ArrangeAsync(string prefix)
     {
-        string userId = await McpTestHelper.CreateUserAsync(factory, prefix);
-        var scope = factory.Services.CreateScope();
+        string userId = await McpTestHelper.CreateUserAsync(Factory, prefix);
+        var scope = Factory.Services.CreateScope();
         _scopes.Add(scope);
         var tokenService = scope.ServiceProvider.GetRequiredService<McpApiTokenService>();
         return (userId, tokenService);
@@ -30,7 +27,7 @@ public class McpApiTokenServiceTests(WebApplicationFactory factory)
 
     private async Task<McpApiTokenService> FillToLimitAsync(string userId)
     {
-        var scope = factory.Services.CreateScope();
+        var scope = Factory.Services.CreateScope();
         _scopes.Add(scope);
         var tokenService = scope.ServiceProvider.GetRequiredService<McpApiTokenService>();
         for (int i = 0; i < McpApiTokenService.MaxTokensPerUser; i++)

--- a/EssentialCSharp.Web.Tests/McpRateLimitingTests.cs
+++ b/EssentialCSharp.Web.Tests/McpRateLimitingTests.cs
@@ -2,27 +2,25 @@ using System.Net;
 using System.Text.Json;
 using EssentialCSharp.Web.Data;
 using EssentialCSharp.Web.Services;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EssentialCSharp.Web.Tests;
 
 /// <summary>
-/// Each class gets its own factory so the global limiter starts from a fresh state.
+/// Each test method gets its own per-test factory (fresh IHost + rate limiter state)
+/// via TUnit.AspNetCore's WebApplicationTest, so [NotInParallel] is no longer needed.
 /// </summary>
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpDistinctUserRateLimitingTests(WebApplicationFactory factory)
+public class McpRateLimitingTests : IntegrationTestBase
 {
     [Test]
     public async Task DistinctValidMcpUsers_DoNotShareRateLimitBucket()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         for (int i = 0; i < 31; i++)
         {
             (_, string rawToken) = await McpTestHelper.CreateUserAndTokenAsync(
-                factory,
+                Factory,
                 $"mcp-rate-limit-isolation-{i}",
                 userPrefix: $"mcp-isolation-{i}");
 
@@ -35,20 +33,15 @@ public class McpDistinctUserRateLimitingTests(WebApplicationFactory factory)
                 .Because($"distinct MCP user request {i + 1} should use its own rate-limit bucket");
         }
     }
-}
 
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpPerUserRateLimitingTests(WebApplicationFactory factory)
-{
     [Test]
     public async Task SingleValidMcpUser_ExceedingTokenBucket_Returns429AndDoesNotCountRejectedRequests()
     {
         (_, string rawToken) = await McpTestHelper.CreateUserAndTokenAsync(
-            factory,
+            Factory,
             "mcp-rate-limit-single-user",
             userPrefix: "mcp-single-user");
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
         List<HttpStatusCode> statuses = [];
         string? rateLimitedPayload = null;
         string? rateLimitedContentType = null;
@@ -70,7 +63,7 @@ public class McpPerUserRateLimitingTests(WebApplicationFactory factory)
             }
         }
 
-        (long UsageCount, bool HasLastUsedAt) tokenUsage = factory.InServiceScope(services =>
+        (long UsageCount, bool HasLastUsedAt) tokenUsage = InServiceScope(services =>
         {
             var db = services.GetRequiredService<EssentialCSharpWebContext>();
             byte[] tokenHash = McpApiTokenService.HashToken(rawToken);
@@ -104,16 +97,11 @@ public class McpPerUserRateLimitingTests(WebApplicationFactory factory)
         await Assert.That(error.GetProperty("code").GetInt32()).IsEqualTo(-32000);
         await Assert.That(error.GetProperty("message").GetString()).Contains("Rate limit exceeded");
     }
-}
 
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpAnonymousRateLimitingTests(WebApplicationFactory factory)
-{
     [Test]
     public async Task InvalidMcpBearerRequests_FallBackToAnonymousIpBucket()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         for (int i = 0; i < McpRateLimiterPolicy.AnonymousPermitLimit; i++)
         {
@@ -132,21 +120,16 @@ public class McpAnonymousRateLimitingTests(WebApplicationFactory factory)
         using HttpResponseMessage rateLimitedResponse = await client.SendAsync(rateLimitedRequest);
         await Assert.That(rateLimitedResponse.StatusCode).IsEqualTo(HttpStatusCode.TooManyRequests);
     }
-}
 
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpCookieIsolationRateLimitingTests(WebApplicationFactory factory)
-{
     [Test]
     public async Task InvalidMcpBearerRequests_WithDifferentSiteCookies_StillShareAnonymousIpBucket()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         for (int i = 0; i < McpRateLimiterPolicy.AnonymousPermitLimit; i++)
         {
-            string cookieUserId = await McpTestHelper.CreateUserAsync(factory, $"mcp-cookie-user-{i}");
-            (string cookieName, string cookieValue) = await McpTestHelper.CreateIdentityApplicationCookieAsync(factory, cookieUserId);
+            string cookieUserId = await McpTestHelper.CreateUserAsync(Factory, $"mcp-cookie-user-{i}");
+            (string cookieName, string cookieValue) = await McpTestHelper.CreateIdentityApplicationCookieAsync(Factory, cookieUserId);
 
             using var request = McpTestHelper.CreateInitializeRequest("/mcp");
             McpTestHelper.AddBearerToken(request, "mcp_invalid_token_that_does_not_exist");
@@ -158,8 +141,8 @@ public class McpCookieIsolationRateLimitingTests(WebApplicationFactory factory)
                 .Because($"invalid MCP bearer request {i + 1} should ignore the site cookie principal and stay in the anonymous/IP bucket");
         }
 
-        string finalCookieUserId = await McpTestHelper.CreateUserAsync(factory, "mcp-cookie-user-final");
-        (string finalCookieName, string finalCookieValue) = await McpTestHelper.CreateIdentityApplicationCookieAsync(factory, finalCookieUserId);
+        string finalCookieUserId = await McpTestHelper.CreateUserAsync(Factory, "mcp-cookie-user-final");
+        (string finalCookieName, string finalCookieValue) = await McpTestHelper.CreateIdentityApplicationCookieAsync(Factory, finalCookieUserId);
 
         using var rateLimitedRequest = McpTestHelper.CreateInitializeRequest("/mcp");
         McpTestHelper.AddBearerToken(rateLimitedRequest, "mcp_invalid_token_that_does_not_exist");
@@ -168,20 +151,15 @@ public class McpCookieIsolationRateLimitingTests(WebApplicationFactory factory)
         using HttpResponseMessage rateLimitedResponse = await client.SendAsync(rateLimitedRequest);
         await Assert.That(rateLimitedResponse.StatusCode).IsEqualTo(HttpStatusCode.TooManyRequests);
     }
-}
 
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpGlobalBypassRateLimitingTests(WebApplicationFactory factory)
-{
     [Test]
     public async Task ValidMcpPostRequests_DoNotConsumeGlobalLimiterBudgetForGetShim()
     {
         (_, string rawToken) = await McpTestHelper.CreateUserAndTokenAsync(
-            factory,
+            Factory,
             "mcp-global-bypass",
             userPrefix: "mcp-bypass");
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         for (int i = 0; i < 10; i++)
         {
@@ -211,16 +189,11 @@ public class McpGlobalBypassRateLimitingTests(WebApplicationFactory factory)
         using HttpResponseMessage rateLimitedGetResponse = await client.SendAsync(rateLimitedGetRequest);
         await Assert.That(rateLimitedGetResponse.StatusCode).IsEqualTo(HttpStatusCode.TooManyRequests);
     }
-}
 
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpWellKnownIsolationRateLimitingTests(WebApplicationFactory factory)
-{
     [Test]
     public async Task WellKnownRequests_DoNotConsumeContentLimiterBudget()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         for (int i = 0; i < 10; i++)
         {
@@ -243,3 +216,4 @@ public class McpWellKnownIsolationRateLimitingTests(WebApplicationFactory factor
         await Assert.That(rateLimitedResponse.StatusCode).IsEqualTo(HttpStatusCode.TooManyRequests);
     }
 }
+

--- a/EssentialCSharp.Web.Tests/McpTestHelper.cs
+++ b/EssentialCSharp.Web.Tests/McpTestHelper.cs
@@ -6,7 +6,6 @@ using EssentialCSharp.Web.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using TUnit.AspNetCore;
@@ -16,10 +15,7 @@ namespace EssentialCSharp.Web.Tests;
 internal static class McpTestHelper
 {
     public static HttpClient CreateClient(TracedWebApplicationFactory<Program> factory) =>
-        factory.Inner.CreateClient(new WebApplicationFactoryClientOptions
-        {
-            AllowAutoRedirect = false
-        });
+        factory.CreateClient();
 
     public static HttpRequestMessage CreateInitializeRequest(string path = "/mcp")
     {

--- a/EssentialCSharp.Web.Tests/McpTestHelper.cs
+++ b/EssentialCSharp.Web.Tests/McpTestHelper.cs
@@ -9,15 +9,17 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using TUnit.AspNetCore;
 
 namespace EssentialCSharp.Web.Tests;
 
 internal static class McpTestHelper
 {
-    public static HttpClient CreateClient(WebApplicationFactory factory) => factory.CreateClient(new WebApplicationFactoryClientOptions
-    {
-        AllowAutoRedirect = false
-    });
+    public static HttpClient CreateClient(TracedWebApplicationFactory<Program> factory) =>
+        factory.Inner.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
 
     public static HttpRequestMessage CreateInitializeRequest(string path = "/mcp")
     {
@@ -50,7 +52,7 @@ internal static class McpTestHelper
     public static void AddCookie(HttpRequestMessage request, string cookieName, string cookieValue) =>
         request.Headers.Add("Cookie", $"{cookieName}={cookieValue}");
 
-    public static async Task<string> CreateUserAsync(WebApplicationFactory factory, string userPrefix)
+    public static async Task<string> CreateUserAsync(TracedWebApplicationFactory<Program> factory, string userPrefix)
     {
         string userId = Guid.NewGuid().ToString();
         string suffix = Guid.NewGuid().ToString("N")[..8];
@@ -73,7 +75,7 @@ internal static class McpTestHelper
     }
 
     public static async Task<(string UserId, string RawToken)> CreateUserAndTokenAsync(
-        WebApplicationFactory factory,
+        TracedWebApplicationFactory<Program> factory,
         string tokenName,
         string userPrefix = "mcp-test",
         DateTime? expiresAt = null)
@@ -90,7 +92,7 @@ internal static class McpTestHelper
     }
 
     public static async Task<(string CookieName, string CookieValue)> CreateIdentityApplicationCookieAsync(
-        WebApplicationFactory factory,
+        TracedWebApplicationFactory<Program> factory,
         string userId)
     {
         using var scope = factory.Services.CreateScope();

--- a/EssentialCSharp.Web.Tests/McpTestHelper.cs
+++ b/EssentialCSharp.Web.Tests/McpTestHelper.cs
@@ -6,6 +6,7 @@ using EssentialCSharp.Web.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using TUnit.AspNetCore;
@@ -15,7 +16,7 @@ namespace EssentialCSharp.Web.Tests;
 internal static class McpTestHelper
 {
     public static HttpClient CreateClient(TracedWebApplicationFactory<Program> factory) =>
-        factory.CreateClient();
+        factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
     public static HttpRequestMessage CreateInitializeRequest(string path = "/mcp")
     {

--- a/EssentialCSharp.Web.Tests/McpTestHelper.cs
+++ b/EssentialCSharp.Web.Tests/McpTestHelper.cs
@@ -16,7 +16,7 @@ namespace EssentialCSharp.Web.Tests;
 internal static class McpTestHelper
 {
     public static HttpClient CreateClient(TracedWebApplicationFactory<Program> factory) =>
-        factory.CreateClient();
+        factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
     public static HttpRequestMessage CreateInitializeRequest(string path = "/mcp")
     {

--- a/EssentialCSharp.Web.Tests/McpTestHelper.cs
+++ b/EssentialCSharp.Web.Tests/McpTestHelper.cs
@@ -16,7 +16,7 @@ namespace EssentialCSharp.Web.Tests;
 internal static class McpTestHelper
 {
     public static HttpClient CreateClient(TracedWebApplicationFactory<Program> factory) =>
-        factory.Inner.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        factory.CreateClient();
 
     public static HttpRequestMessage CreateInitializeRequest(string path = "/mcp")
     {

--- a/EssentialCSharp.Web.Tests/McpTests.cs
+++ b/EssentialCSharp.Web.Tests/McpTests.cs
@@ -1,19 +1,16 @@
 using System.Net;
 using System.Text;
 using EssentialCSharp.Web.Services;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EssentialCSharp.Web.Tests;
 
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpTests(WebApplicationFactory factory)
+public class McpTests : IntegrationTestBase
 {
     [Test]
     public async Task McpTokenEndpoint_WithoutAuth_Returns401()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         using HttpResponseMessage response = await client.PostAsync("/api/McpToken", null);
 
@@ -23,7 +20,7 @@ public class McpTests(WebApplicationFactory factory)
     [Test]
     public async Task McpEndpoint_WithoutToken_Returns401()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         using var request = McpTestHelper.CreateInitializeRequest("/mcp");
         using HttpResponseMessage response = await client.SendAsync(request);
@@ -34,11 +31,11 @@ public class McpTests(WebApplicationFactory factory)
     [Test]
     public async Task McpEndpoint_WithSiteCookieButWithoutBearer_Returns401()
     {
-        string cookieUserId = await McpTestHelper.CreateUserAsync(factory, "mcp-cookie-only");
+        string cookieUserId = await McpTestHelper.CreateUserAsync(Factory, "mcp-cookie-only");
         (string cookieName, string cookieValue) =
-            await McpTestHelper.CreateIdentityApplicationCookieAsync(factory, cookieUserId);
+            await McpTestHelper.CreateIdentityApplicationCookieAsync(Factory, cookieUserId);
 
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
         using var request = McpTestHelper.CreateInitializeRequest("/mcp");
         McpTestHelper.AddCookie(request, cookieName, cookieValue);
 
@@ -51,11 +48,11 @@ public class McpTests(WebApplicationFactory factory)
     public async Task McpEndpoint_WithValidToken_Returns200AndListsTools()
     {
         (_, string rawToken) = await McpTestHelper.CreateUserAndTokenAsync(
-            factory,
+            Factory,
             "integration-test",
             userPrefix: "mcp-testuser");
 
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         // Step 1: Initialize the MCP session
         using var initRequest = McpTestHelper.CreateInitializeRequest("/mcp");
@@ -108,7 +105,7 @@ public class McpTests(WebApplicationFactory factory)
     [Test]
     public async Task McpEndpoint_WithInvalidToken_Returns401()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
         using var request = McpTestHelper.CreateInitializeRequest("/mcp");
         McpTestHelper.AddBearerToken(request, "mcp_invalid_token_that_does_not_exist");
         using HttpResponseMessage response = await client.SendAsync(request);
@@ -118,16 +115,16 @@ public class McpTests(WebApplicationFactory factory)
     [Test]
     public async Task McpEndpoint_WithRevokedToken_Returns401()
     {
-        string testUserId = await McpTestHelper.CreateUserAsync(factory, "revoked-user");
+        string testUserId = await McpTestHelper.CreateUserAsync(Factory, "revoked-user");
         string rawToken;
-        using (var scope = factory.Services.CreateScope())
+        using (var scope = Factory.Services.CreateScope())
         {
             var tokenService = scope.ServiceProvider.GetRequiredService<McpApiTokenService>();
             (rawToken, var entity) = await tokenService.CreateTokenAsync(testUserId, "revoke-test");
             await tokenService.RevokeTokenAsync(entity.Id, testUserId);
         }
 
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
         using var request = McpTestHelper.CreateInitializeRequest("/mcp");
         McpTestHelper.AddBearerToken(request, rawToken);
         using HttpResponseMessage response = await client.SendAsync(request);
@@ -138,12 +135,12 @@ public class McpTests(WebApplicationFactory factory)
     public async Task McpEndpoint_WithExpiredToken_Returns401()
     {
         (_, string rawToken) = await McpTestHelper.CreateUserAndTokenAsync(
-            factory,
+            Factory,
             "expired-test",
             userPrefix: "expired-user",
             expiresAt: DateTime.UtcNow.AddSeconds(-1));
 
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
         using var request = McpTestHelper.CreateInitializeRequest("/mcp");
         McpTestHelper.AddBearerToken(request, rawToken);
         using HttpResponseMessage response = await client.SendAsync(request);
@@ -153,7 +150,7 @@ public class McpTests(WebApplicationFactory factory)
     [Test]
     public async Task WellKnownOAuthProtectedResource_AllMethodsReturn404WithoutRedirectAndNoStore()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         foreach (HttpMethod method in new[] { HttpMethod.Get, HttpMethod.Post, HttpMethod.Options })
         {
@@ -171,7 +168,7 @@ public class McpTests(WebApplicationFactory factory)
     [Test]
     public async Task McpEndpoint_PreflightFromLoopbackOrigin_ReturnsCorsHeaders()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
         using var request = new HttpRequestMessage(HttpMethod.Options, "/mcp");
         request.Headers.Add("Origin", "http://localhost:6274");
         request.Headers.Add("Access-Control-Request-Method", "POST");
@@ -191,7 +188,7 @@ public class McpTests(WebApplicationFactory factory)
     [Test]
     public async Task McpEndpoint_GetFromLoopbackOrigin_Returns405WithoutRedirect()
     {
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
         using var request = new HttpRequestMessage(HttpMethod.Get, "/mcp");
         request.Headers.Add("Origin", "http://localhost:6274");
         request.Headers.Accept.ParseAdd("text/event-stream");

--- a/EssentialCSharp.Web.Tests/McpToolContractTests.cs
+++ b/EssentialCSharp.Web.Tests/McpToolContractTests.cs
@@ -2,15 +2,12 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using EssentialCSharp.Web.Services;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Tests;
 
-[NotInParallel("McpTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class McpToolContractTests(WebApplicationFactory factory)
+public class McpToolContractTests : IntegrationTestBase
 {
     [Test]
     public async Task McpToolsList_StructuredAndHybridTools_AdvertiseOutputSchema()
@@ -201,10 +198,10 @@ public class McpToolContractTests(WebApplicationFactory factory)
     private async Task<(HttpClient Client, string RawToken, string? SessionId)> CreateAuthenticatedSessionAsync()
     {
         (_, string rawToken) = await McpTestHelper.CreateUserAndTokenAsync(
-            factory,
+            Factory,
             "mcp-contract-test",
             userPrefix: "mcp-contract");
-        HttpClient client = McpTestHelper.CreateClient(factory);
+        HttpClient client = McpTestHelper.CreateClient(Factory);
 
         using var initRequest = McpTestHelper.CreateInitializeRequest("/mcp");
         McpTestHelper.AddBearerToken(initRequest, rawToken);
@@ -223,7 +220,7 @@ public class McpToolContractTests(WebApplicationFactory factory)
 
     private string GetConfiguredBaseUrl()
     {
-        string baseUrl = factory.Services.GetRequiredService<IOptions<SiteSettings>>().Value.BaseUrl;
+        string baseUrl = Factory.Services.GetRequiredService<IOptions<SiteSettings>>().Value.BaseUrl;
         return baseUrl.TrimEnd('/') + "/";
     }
 

--- a/EssentialCSharp.Web.Tests/RouteConfigurationServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/RouteConfigurationServiceTests.cs
@@ -3,21 +3,13 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace EssentialCSharp.Web.Tests;
 
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class RouteConfigurationServiceTests
+public class RouteConfigurationServiceTests : IntegrationTestBase
 {
-    private readonly WebApplicationFactory _Factory;
-
-    public RouteConfigurationServiceTests(WebApplicationFactory factory)
-    {
-        _Factory = factory;
-    }
-
     [Test]
     public async Task GetStaticRoutes_ShouldReturnExpectedRoutes()
     {
         // Act
-        var routes = _Factory.InServiceScope(serviceProvider =>
+        var routes = InServiceScope(serviceProvider =>
         {
             var routeConfigurationService = serviceProvider.GetRequiredService<IRouteConfigurationService>();
             return routeConfigurationService.GetStaticRoutes().ToList();

--- a/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
+++ b/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
@@ -3,20 +3,10 @@ using DotnetSitemapGenerator;
 using EssentialCSharp.Web.Helpers;
 using EssentialCSharp.Web.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 namespace EssentialCSharp.Web.Tests;
 
-[NotInParallel("SitemapTests")]
-[ClassDataSource<WebApplicationFactory>(Shared = SharedType.PerClass)]
-public class SitemapXmlHelpersTests
+public class SitemapXmlHelpersTests : IntegrationTestBase
 {
-    private readonly WebApplicationFactory _Factory;
-
-    public SitemapXmlHelpersTests(WebApplicationFactory factory)
-    {
-        _Factory = factory;
-    }
-
     [Test]
     public async Task EnsureSitemapHealthy_WithValidSiteMappings_DoesNotThrow()
     {
@@ -73,7 +63,7 @@ public class SitemapXmlHelpersTests
         var baseUrl = "https://test.example.com/";
 
         // Act & Assert
-        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
         SitemapXmlHelpers.GenerateSitemapXml(
             siteMappings,
             routeConfigurationService,
@@ -99,7 +89,7 @@ public class SitemapXmlHelpersTests
         var baseUrl = "https://test.example.com/";
 
         // Act & Assert
-        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
         SitemapXmlHelpers.GenerateSitemapXml(
             siteMappings,
             routeConfigurationService,
@@ -131,7 +121,7 @@ public class SitemapXmlHelpersTests
         };
 
         // Act & Assert
-        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
         SitemapXmlHelpers.GenerateSitemapXml(
             siteMappings,
             routeConfigurationService,
@@ -153,7 +143,7 @@ public class SitemapXmlHelpersTests
         var baseUrl = "https://test.example.com/";
 
         // Act & Assert
-        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
         SitemapXmlHelpers.GenerateSitemapXml(
             siteMappings,
             routeConfigurationService,
@@ -174,7 +164,7 @@ public class SitemapXmlHelpersTests
         var baseUrl = "https://test.example.com/";
 
         // Act & Assert
-        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
         SitemapXmlHelpers.GenerateSitemapXml(
             siteMappings,
             routeConfigurationService,
@@ -195,7 +185,7 @@ public class SitemapXmlHelpersTests
         var baseUrl = "https://test.example.com/";
 
         // Act
-        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
         SitemapXmlHelpers.GenerateSitemapXml(
             siteMappings,
             routeConfigurationService,
@@ -221,7 +211,7 @@ public class SitemapXmlHelpersTests
         };
 
         // Act
-        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
         SitemapXmlHelpers.GenerateSitemapXml(
             siteMappings,
             routeConfigurationService,
@@ -244,7 +234,7 @@ public class SitemapXmlHelpersTests
         };
 
         // Act
-        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
         SitemapXmlHelpers.GenerateSitemapXml(
             siteMappings,
             routeConfigurationService,

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -1,9 +1,9 @@
+using System.Collections.Concurrent;
 using System.Data.Common;
 using EssentialCSharp.Web.Data;
 using EssentialCSharp.Web.Services;
-using TUnit.Core.Interfaces;
+using TUnit.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -12,19 +12,12 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace EssentialCSharp.Web.Tests;
 
-public sealed class WebApplicationFactory : WebApplicationFactory<Program>, IAsyncInitializer
+public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 {
-    public Task InitializeAsync()
-    {
-        // Force eager server initialization before tests run.
-        // This is thread-safe and prevents race conditions from parallel tests
-        // calling CreateClient() concurrently during lazy init.
-        _ = Server;
-        return Task.CompletedTask;
-    }
-
     private static string SqlConnectionString => $"DataSource=file:{Guid.NewGuid()}?mode=memory&cache=shared";
-    private SqliteConnection? _Connection;
+
+    // Each per-test factory's ConfigureWebHost creates a new connection; track all for disposal.
+    private readonly ConcurrentBag<SqliteConnection> _connections = [];
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -58,12 +51,15 @@ public sealed class WebApplicationFactory : WebApplicationFactory<Program>, IAsy
                 services.Remove(migrationServiceDescriptor);
             }
 
-            _Connection = new SqliteConnection(SqlConnectionString);
-            _Connection.Open();
+            // Capture in a local variable so each per-test factory's closure binds
+            // to its own connection, not to a shared field that gets overwritten.
+            SqliteConnection connection = new(SqlConnectionString);
+            connection.Open();
+            _connections.Add(connection);
 
             services.AddDbContext<EssentialCSharpWebContext>(options =>
             {
-                options.UseSqlite(_Connection);
+                options.UseSqlite(connection);
             });
 
             using ServiceProvider serviceProvider = services.BuildServiceProvider();
@@ -80,37 +76,12 @@ public sealed class WebApplicationFactory : WebApplicationFactory<Program>, IAsy
         });
     }
 
-    /// <summary>
-    /// Executes an action within a service scope, handling scope creation and cleanup automatically.
-    /// </summary>
-    /// <typeparam name="T">The return type of the action</typeparam>
-    /// <param name="action">The action to execute with the scoped service provider</param>
-    /// <returns>The result of the action</returns>
-    public T InServiceScope<T>(Func<IServiceProvider, T> action)
-    {
-        var factory = Services.GetRequiredService<IServiceScopeFactory>();
-        using var scope = factory.CreateScope();
-        return action(scope.ServiceProvider);
-    }
-
-    /// <summary>
-    /// Executes an action within a service scope, handling scope creation and cleanup automatically.
-    /// </summary>
-    /// <param name="action">The action to execute with the scoped service provider</param>
-    public void InServiceScope(Action<IServiceProvider> action)
-    {
-        var factory = Services.GetRequiredService<IServiceScopeFactory>();
-        using var scope = factory.CreateScope();
-        action(scope.ServiceProvider);
-    }
-
     public override async ValueTask DisposeAsync()
     {
         await base.DisposeAsync().ConfigureAwait(false);
-        if (_Connection != null)
+        foreach (SqliteConnection connection in _connections)
         {
-            await _Connection.DisposeAsync().ConfigureAwait(false);
-            _Connection = null;
+            await connection.DisposeAsync().ConfigureAwait(false);
         }
         GC.SuppressFinalize(this);
     }
@@ -120,8 +91,10 @@ public sealed class WebApplicationFactory : WebApplicationFactory<Program>, IAsy
         base.Dispose(disposing);
         if (disposing)
         {
-            _Connection?.Dispose();
-            _Connection = null;
+            foreach (SqliteConnection connection in _connections)
+            {
+                connection.Dispose();
+            }
         }
     }
 }

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -17,7 +17,9 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
     // One GUID per factory instance (field, not computed property) ensures each factory
     // gets its own isolated in-memory database and keeps a stable connection string.
     private readonly string _sqlConnectionString =
-        $"DataSource=file:{Guid.NewGuid():N}?mode=memory&cache=shared;Pooling=True";
+        $"DataSource=file:{Guid.NewGuid():N}?mode=memory&cache=shared";
+
+    private readonly SemaphoreSlim _schemaInitializationGate = new(1, 1);
 
     // Kept open for the factory lifetime so the shared-cache in-memory database is not dropped
     // when per-scope connections are disposed between requests.
@@ -79,7 +81,10 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                 nameof(EnsureCreatedHostedService));
 
             ServiceDescriptor ensureCreatedDescriptor =
-                ServiceDescriptor.Singleton<IHostedService, EnsureCreatedHostedService>();
+                ServiceDescriptor.Singleton<IHostedService>(
+                    serviceProvider => new EnsureCreatedHostedService(
+                        serviceProvider,
+                        _schemaInitializationGate));
             services.Insert(0, ensureCreatedDescriptor);
 
             // Replace IListingSourceCodeService with one backed by TestData
@@ -124,14 +129,24 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
         }
     }
 
-    private sealed class EnsureCreatedHostedService(IServiceProvider serviceProvider) : IHostedService
+    private sealed class EnsureCreatedHostedService(
+        IServiceProvider serviceProvider,
+        SemaphoreSlim schemaInitializationGate) : IHostedService
     {
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            using IServiceScope scope = serviceProvider.CreateScope();
-            EssentialCSharpWebContext dbContext =
-                scope.ServiceProvider.GetRequiredService<EssentialCSharpWebContext>();
-            await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+            await schemaInitializationGate.WaitAsync(cancellationToken);
+            try
+            {
+                using IServiceScope scope = serviceProvider.CreateScope();
+                EssentialCSharpWebContext dbContext =
+                    scope.ServiceProvider.GetRequiredService<EssentialCSharpWebContext>();
+                await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+            }
+            finally
+            {
+                schemaInitializationGate.Release();
+            }
         }
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -56,7 +56,8 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                 options.UseSqlite(dbConnection);
             });
 
-            services.AddHostedService<EnsureCreatedHostedService>();
+            // Ensure schema exists before any other hosted service that reads from the database.
+            services.Insert(0, ServiceDescriptor.Singleton<IHostedService, EnsureCreatedHostedService>());
 
             // Replace IListingSourceCodeService with one backed by TestData
             services.RemoveAll<IListingSourceCodeService>();

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -56,8 +56,26 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                 options.UseSqlite(dbConnection);
             });
 
-            // Ensure schema exists before any other hosted service that reads from the database.
-            services.Insert(0, ServiceDescriptor.Singleton<IHostedService, EnsureCreatedHostedService>());
+            // Ensure schema exists before any hosted service that reads from the database.
+            ServiceDescriptor ensureCreatedDescriptor =
+                ServiceDescriptor.Singleton<IHostedService, EnsureCreatedHostedService>();
+            int firstHostedServiceIndex = -1;
+            for (int i = 0; i < services.Count; i++)
+            {
+                if (services[i].ServiceType == typeof(IHostedService))
+                {
+                    firstHostedServiceIndex = i;
+                    break;
+                }
+            }
+            if (firstHostedServiceIndex >= 0)
+            {
+                services.Insert(firstHostedServiceIndex, ensureCreatedDescriptor);
+            }
+            else
+            {
+                services.Add(ensureCreatedDescriptor);
+            }
 
             // Replace IListingSourceCodeService with one backed by TestData
             services.RemoveAll<IListingSourceCodeService>();

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace EssentialCSharp.Web.Tests;
 
@@ -47,12 +48,7 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                 services.Remove(migrationServiceDescriptor);
             }
 
-            // Capture in a local variable so each per-test factory's closure binds
-            // to its own connection, not to a shared field that gets overwritten.
-            SqliteConnection connection = new(SqlConnectionString);
-            connection.Open();
-
-            services.AddSingleton<DbConnection>(connection);
+            services.AddSingleton<DbConnection>(_ => CreateOpenSqliteConnection());
 
             services.AddDbContext<EssentialCSharpWebContext>((serviceProvider, options) =>
             {
@@ -60,18 +56,32 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                 options.UseSqlite(dbConnection);
             });
 
-            DbContextOptions<EssentialCSharpWebContext> dbContextOptions =
-                new DbContextOptionsBuilder<EssentialCSharpWebContext>()
-                    .UseSqlite(connection)
-                    .Options;
-            using EssentialCSharpWebContext db = new(dbContextOptions);
-
-            db.Database.EnsureCreated();
+            services.AddHostedService<EnsureCreatedHostedService>();
 
             // Replace IListingSourceCodeService with one backed by TestData
             services.RemoveAll<IListingSourceCodeService>();
             services.AddSingleton<IListingSourceCodeService>(
                 _ => TestListingSourceCodeServiceHelper.CreateService());
         });
+    }
+
+    private static SqliteConnection CreateOpenSqliteConnection()
+    {
+        SqliteConnection connection = new(SqlConnectionString);
+        connection.Open();
+        return connection;
+    }
+
+    private sealed class EnsureCreatedHostedService(IServiceProvider serviceProvider) : IHostedService
+    {
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            using IServiceScope scope = serviceProvider.CreateScope();
+            EssentialCSharpWebContext dbContext =
+                scope.ServiceProvider.GetRequiredService<EssentialCSharpWebContext>();
+            await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -23,7 +23,13 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 
     // Kept open for the factory lifetime so the shared-cache in-memory database is not dropped
     // when per-scope connections are disposed between requests.
-    private SqliteConnection? _keepAliveConnection;
+    private readonly SqliteConnection _keepAliveConnection;
+
+    public WebApplicationFactory()
+    {
+        _keepAliveConnection = new SqliteConnection(_sqlConnectionString);
+        _keepAliveConnection.Open();
+    }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -50,12 +56,6 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 
             // Open a keep-alive connection to prevent the shared-cache in-memory database from
             // being dropped when per-scope connections are disposed between requests.
-            _keepAliveConnection ??= new SqliteConnection(_sqlConnectionString);
-            if (_keepAliveConnection.State != System.Data.ConnectionState.Open)
-            {
-                _keepAliveConnection.Open();
-            }
-
             // Register as scoped so each request scope gets its own SqliteConnection,
             // preventing "database is locked" errors under concurrent requests.
             services.AddScoped<DbConnection>(_ =>
@@ -98,7 +98,8 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
     {
         if (disposing)
         {
-            _keepAliveConnection?.Dispose();
+            _keepAliveConnection.Dispose();
+            _schemaInitializationGate.Dispose();
         }
         base.Dispose(disposing);
     }

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -76,8 +76,11 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
         });
     }
 
+    private int _disposed;
+
     public override async ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
         await base.DisposeAsync().ConfigureAwait(false);
         foreach (SqliteConnection connection in _connections)
         {
@@ -88,6 +91,7 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 
     protected override void Dispose(bool disposing)
     {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
         base.Dispose(disposing);
         if (disposing)
         {

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -9,17 +9,15 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
-using System.Threading;
 
 namespace EssentialCSharp.Web.Tests;
 
 public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 {
-    private static readonly SemaphoreSlim SchemaInitializationGate = new(1, 1);
     // One GUID per factory instance (field, not computed property) ensures each factory
     // gets its own isolated in-memory database and keeps a stable connection string.
     private readonly string _sqlConnectionString =
-        $"DataSource=file:{Guid.NewGuid():N}?mode=memory&cache=shared";
+        $"DataSource=file:{Guid.NewGuid():N}?mode=memory&cache=shared;Pooling=True";
 
     // Kept open for the factory lifetime so the shared-cache in-memory database is not dropped
     // when per-scope connections are disposed between requests.
@@ -65,6 +63,8 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                 return conn;
             });
 
+            // The scoped DI container owns this DbConnection instance and disposes it at
+            // scope end; EF Core treats it as externally owned when passed via UseSqlite.
             services.AddDbContext<EssentialCSharpWebContext>((serviceProvider, options) =>
             {
                 DbConnection dbConnection = serviceProvider.GetRequiredService<DbConnection>();
@@ -80,23 +80,7 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 
             ServiceDescriptor ensureCreatedDescriptor =
                 ServiceDescriptor.Singleton<IHostedService, EnsureCreatedHostedService>();
-            int firstHostedServiceIndex = -1;
-            for (int i = 0; i < services.Count; i++)
-            {
-                if (services[i].ServiceType == typeof(IHostedService))
-                {
-                    firstHostedServiceIndex = i;
-                    break;
-                }
-            }
-            if (firstHostedServiceIndex >= 0)
-            {
-                services.Insert(firstHostedServiceIndex, ensureCreatedDescriptor);
-            }
-            else
-            {
-                services.Add(ensureCreatedDescriptor);
-            }
+            services.Insert(0, ensureCreatedDescriptor);
 
             // Replace IListingSourceCodeService with one backed by TestData
             services.RemoveAll<IListingSourceCodeService>();
@@ -144,18 +128,10 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
     {
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            await SchemaInitializationGate.WaitAsync(cancellationToken);
-            try
-            {
-                using IServiceScope scope = serviceProvider.CreateScope();
-                EssentialCSharpWebContext dbContext =
-                    scope.ServiceProvider.GetRequiredService<EssentialCSharpWebContext>();
-                await dbContext.Database.EnsureCreatedAsync(cancellationToken);
-            }
-            finally
-            {
-                SchemaInitializationGate.Release();
-            }
+            using IServiceScope scope = serviceProvider.CreateScope();
+            EssentialCSharpWebContext dbContext =
+                scope.ServiceProvider.GetRequiredService<EssentialCSharpWebContext>();
+            await dbContext.Database.EnsureCreatedAsync(cancellationToken);
         }
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -14,7 +14,13 @@ namespace EssentialCSharp.Web.Tests;
 
 public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 {
-    private static string SqlConnectionString => $"DataSource=file:{Guid.NewGuid()}?mode=memory&cache=shared";
+    // One GUID per factory instance → each factory gets its own isolated in-memory database.
+    private readonly string _sqlConnectionString =
+        $"DataSource=file:{Guid.NewGuid():N}?mode=memory&cache=shared";
+
+    // Kept open for the factory lifetime so the shared-cache in-memory database is not dropped
+    // when per-scope connections are disposed between requests.
+    private SqliteConnection? _keepAliveConnection;
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -48,7 +54,19 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                 services.Remove(migrationServiceDescriptor);
             }
 
-            services.AddSingleton<DbConnection>(_ => CreateOpenSqliteConnection());
+            // Open a keep-alive connection to prevent the shared-cache in-memory database from
+            // being dropped when per-scope connections are disposed between requests.
+            _keepAliveConnection = new SqliteConnection(_sqlConnectionString);
+            _keepAliveConnection.Open();
+
+            // Register as scoped so each request scope gets its own SqliteConnection,
+            // preventing "database is locked" errors under concurrent requests.
+            services.AddScoped<DbConnection>(_ =>
+            {
+                SqliteConnection conn = new(_sqlConnectionString);
+                conn.Open();
+                return conn;
+            });
 
             services.AddDbContext<EssentialCSharpWebContext>((serviceProvider, options) =>
             {
@@ -84,11 +102,13 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
         });
     }
 
-    private static SqliteConnection CreateOpenSqliteConnection()
+    protected override void Dispose(bool disposing)
     {
-        SqliteConnection connection = new(SqlConnectionString);
-        connection.Open();
-        return connection;
+        if (disposing)
+        {
+            _keepAliveConnection?.Dispose();
+        }
+        base.Dispose(disposing);
     }
 
     private sealed class EnsureCreatedHostedService(IServiceProvider serviceProvider) : IHostedService

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -76,29 +76,25 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
         });
     }
 
-    private int _disposed;
+    private int _connectionsDisposed;
 
     public override async ValueTask DisposeAsync()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
         await base.DisposeAsync().ConfigureAwait(false);
-        foreach (SqliteConnection connection in _connections)
+        if (Interlocked.Exchange(ref _connectionsDisposed, 1) == 0)
         {
-            await connection.DisposeAsync().ConfigureAwait(false);
+            foreach (SqliteConnection connection in _connections)
+                await connection.DisposeAsync().ConfigureAwait(false);
         }
-        GC.SuppressFinalize(this);
     }
 
     protected override void Dispose(bool disposing)
     {
-        if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
         base.Dispose(disposing);
-        if (disposing)
+        if (disposing && Interlocked.Exchange(ref _connectionsDisposed, 1) == 0)
         {
             foreach (SqliteConnection connection in _connections)
-            {
                 connection.Dispose();
-            }
         }
     }
 }

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -26,38 +26,42 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
     {
         builder.ConfigureServices(services =>
         {
-            ServiceDescriptor? dbContextDescriptor = services.SingleOrDefault(
-                d => d.ServiceType ==
-                    typeof(IDbContextOptionsConfiguration<EssentialCSharpWebContext>));
-
-            if (dbContextDescriptor != null)
+            for (int i = services.Count - 1; i >= 0; i--)
             {
-                services.Remove(dbContextDescriptor);
+                if (services[i].ServiceType ==
+                    typeof(IDbContextOptionsConfiguration<EssentialCSharpWebContext>))
+                {
+                    services.RemoveAt(i);
+                }
             }
 
-            ServiceDescriptor? dbConnectionDescriptor =
-                services.SingleOrDefault(
-                    d => d.ServiceType ==
-                    typeof(DbConnection));
-
-            if (dbConnectionDescriptor != null)
+            for (int i = services.Count - 1; i >= 0; i--)
             {
-                services.Remove(dbConnectionDescriptor);
+                if (services[i].ServiceType == typeof(DbConnection))
+                {
+                    services.RemoveAt(i);
+                }
             }
 
             // Remove DatabaseMigrationService: it calls MigrateAsync which conflicts
             // with EnsureCreated() used below for the in-memory SQLite test database.
-            ServiceDescriptor? migrationServiceDescriptor = services.SingleOrDefault(
-                d => d.ImplementationType == typeof(DatabaseMigrationService));
-            if (migrationServiceDescriptor != null)
+            for (int i = services.Count - 1; i >= 0; i--)
             {
-                services.Remove(migrationServiceDescriptor);
+                ServiceDescriptor descriptor = services[i];
+                if (descriptor.ServiceType == typeof(IHostedService) &&
+                    descriptor.ImplementationType == typeof(DatabaseMigrationService))
+                {
+                    services.RemoveAt(i);
+                }
             }
 
             // Open a keep-alive connection to prevent the shared-cache in-memory database from
             // being dropped when per-scope connections are disposed between requests.
-            _keepAliveConnection = new SqliteConnection(_sqlConnectionString);
-            _keepAliveConnection.Open();
+            _keepAliveConnection ??= new SqliteConnection(_sqlConnectionString);
+            if (_keepAliveConnection.State != System.Data.ConnectionState.Open)
+            {
+                _keepAliveConnection.Open();
+            }
 
             // Register as scoped so each request scope gets its own SqliteConnection,
             // preventing "database is locked" errors under concurrent requests.
@@ -75,6 +79,16 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
             });
 
             // Ensure schema exists before any hosted service that reads from the database.
+            for (int i = services.Count - 1; i >= 0; i--)
+            {
+                ServiceDescriptor descriptor = services[i];
+                if (descriptor.ServiceType == typeof(IHostedService) &&
+                    descriptor.ImplementationType == typeof(EnsureCreatedHostedService))
+                {
+                    services.RemoveAt(i);
+                }
+            }
+
             ServiceDescriptor ensureCreatedDescriptor =
                 ServiceDescriptor.Singleton<IHostedService, EnsureCreatedHostedService>();
             int firstHostedServiceIndex = -1;

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -54,14 +54,20 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                     descriptor.ImplementationType == typeof(DatabaseMigrationService),
                 nameof(DatabaseMigrationService));
 
-            // Open a keep-alive connection to prevent the shared-cache in-memory database from
-            // being dropped when per-scope connections are disposed between requests.
-            // Register as scoped so each request scope gets its own SqliteConnection,
-            // preventing "database is locked" errors under concurrent requests.
+            // Keep per-scope connections so each request/test scope uses a fresh DbConnection,
+            // which avoids locking issues from sharing one SqliteConnection instance.
             services.AddScoped<DbConnection>(_ =>
             {
                 SqliteConnection conn = new(_sqlConnectionString);
-                conn.Open();
+                try
+                {
+                    conn.Open();
+                }
+                catch
+                {
+                    conn.Dispose();
+                    throw;
+                }
                 return conn;
             });
 
@@ -73,7 +79,8 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
                 options.UseSqlite(dbConnection);
             });
 
-            // Ensure schema exists before any hosted service that reads from the database.
+            // Ensure schema exists before hosted services by prepending this registration
+            // at index 0 of the service collection.
             RemoveSingleOrNone(
                 services,
                 descriptor => descriptor.ServiceType == typeof(IHostedService) &&

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -16,7 +16,8 @@ namespace EssentialCSharp.Web.Tests;
 public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 {
     private static readonly SemaphoreSlim SchemaInitializationGate = new(1, 1);
-    // One GUID per factory instance → each factory gets its own isolated in-memory database.
+    // One GUID per factory instance (field, not computed property) ensures each factory
+    // gets its own isolated in-memory database and keeps a stable connection string.
     private readonly string _sqlConnectionString =
         $"DataSource=file:{Guid.NewGuid():N}?mode=memory&cache=shared";
 
@@ -28,34 +29,24 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
     {
         builder.ConfigureServices(services =>
         {
-            for (int i = services.Count - 1; i >= 0; i--)
-            {
-                if (services[i].ServiceType ==
-                    typeof(IDbContextOptionsConfiguration<EssentialCSharpWebContext>))
-                {
-                    services.RemoveAt(i);
-                }
-            }
+            RemoveSingleOrNone(
+                services,
+                descriptor => descriptor.ServiceType ==
+                    typeof(IDbContextOptionsConfiguration<EssentialCSharpWebContext>),
+                "IDbContextOptionsConfiguration<EssentialCSharpWebContext>");
 
-            for (int i = services.Count - 1; i >= 0; i--)
-            {
-                if (services[i].ServiceType == typeof(DbConnection))
-                {
-                    services.RemoveAt(i);
-                }
-            }
+            RemoveSingleOrNone(
+                services,
+                descriptor => descriptor.ServiceType == typeof(DbConnection),
+                nameof(DbConnection));
 
             // Remove DatabaseMigrationService: it calls MigrateAsync which conflicts
             // with EnsureCreated() used below for the in-memory SQLite test database.
-            for (int i = services.Count - 1; i >= 0; i--)
-            {
-                ServiceDescriptor descriptor = services[i];
-                if (descriptor.ServiceType == typeof(IHostedService) &&
-                    descriptor.ImplementationType == typeof(DatabaseMigrationService))
-                {
-                    services.RemoveAt(i);
-                }
-            }
+            RemoveSingleOrNone(
+                services,
+                descriptor => descriptor.ServiceType == typeof(IHostedService) &&
+                    descriptor.ImplementationType == typeof(DatabaseMigrationService),
+                nameof(DatabaseMigrationService));
 
             // Open a keep-alive connection to prevent the shared-cache in-memory database from
             // being dropped when per-scope connections are disposed between requests.
@@ -81,15 +72,11 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
             });
 
             // Ensure schema exists before any hosted service that reads from the database.
-            for (int i = services.Count - 1; i >= 0; i--)
-            {
-                ServiceDescriptor descriptor = services[i];
-                if (descriptor.ServiceType == typeof(IHostedService) &&
-                    descriptor.ImplementationType == typeof(EnsureCreatedHostedService))
-                {
-                    services.RemoveAt(i);
-                }
-            }
+            RemoveSingleOrNone(
+                services,
+                descriptor => descriptor.ServiceType == typeof(IHostedService) &&
+                    descriptor.ImplementationType == typeof(EnsureCreatedHostedService),
+                nameof(EnsureCreatedHostedService));
 
             ServiceDescriptor ensureCreatedDescriptor =
                 ServiceDescriptor.Singleton<IHostedService, EnsureCreatedHostedService>();
@@ -125,6 +112,32 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
             _keepAliveConnection?.Dispose();
         }
         base.Dispose(disposing);
+    }
+
+    private static void RemoveSingleOrNone(
+        IServiceCollection services,
+        Func<ServiceDescriptor, bool> predicate,
+        string descriptorName)
+    {
+        List<int> matchIndexes = [];
+        for (int i = 0; i < services.Count; i++)
+        {
+            if (predicate(services[i]))
+            {
+                matchIndexes.Add(i);
+            }
+        }
+
+        if (matchIndexes.Count > 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected at most one '{descriptorName}' registration but found {matchIndexes.Count}.");
+        }
+
+        if (matchIndexes.Count == 1)
+        {
+            services.RemoveAt(matchIndexes[0]);
+        }
     }
 
     private sealed class EnsureCreatedHostedService(IServiceProvider serviceProvider) : IHostedService

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Data.Common;
 using EssentialCSharp.Web.Data;
 using EssentialCSharp.Web.Services;
@@ -15,9 +14,6 @@ namespace EssentialCSharp.Web.Tests;
 public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 {
     private static string SqlConnectionString => $"DataSource=file:{Guid.NewGuid()}?mode=memory&cache=shared";
-
-    // Each per-test factory's ConfigureWebHost creates a new connection; track all for disposal.
-    private readonly ConcurrentBag<SqliteConnection> _connections = [];
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -55,17 +51,20 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
             // to its own connection, not to a shared field that gets overwritten.
             SqliteConnection connection = new(SqlConnectionString);
             connection.Open();
-            _connections.Add(connection);
 
-            services.AddDbContext<EssentialCSharpWebContext>(options =>
+            services.AddSingleton<DbConnection>(connection);
+
+            services.AddDbContext<EssentialCSharpWebContext>((serviceProvider, options) =>
             {
-                options.UseSqlite(connection);
+                DbConnection dbConnection = serviceProvider.GetRequiredService<DbConnection>();
+                options.UseSqlite(dbConnection);
             });
 
-            using ServiceProvider serviceProvider = services.BuildServiceProvider();
-            using IServiceScope scope = serviceProvider.CreateScope();
-            IServiceProvider scopedServices = scope.ServiceProvider;
-            EssentialCSharpWebContext db = scopedServices.GetRequiredService<EssentialCSharpWebContext>();
+            DbContextOptions<EssentialCSharpWebContext> dbContextOptions =
+                new DbContextOptionsBuilder<EssentialCSharpWebContext>()
+                    .UseSqlite(connection)
+                    .Options;
+            using EssentialCSharpWebContext db = new(dbContextOptions);
 
             db.Database.EnsureCreated();
 
@@ -74,27 +73,5 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
             services.AddSingleton<IListingSourceCodeService>(
                 _ => TestListingSourceCodeServiceHelper.CreateService());
         });
-    }
-
-    private int _connectionsDisposed;
-
-    public override async ValueTask DisposeAsync()
-    {
-        await base.DisposeAsync().ConfigureAwait(false);
-        if (Interlocked.Exchange(ref _connectionsDisposed, 1) == 0)
-        {
-            foreach (SqliteConnection connection in _connections)
-                await connection.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-        if (disposing && Interlocked.Exchange(ref _connectionsDisposed, 1) == 0)
-        {
-            foreach (SqliteConnection connection in _connections)
-                connection.Dispose();
-        }
     }
 }

--- a/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
+++ b/EssentialCSharp.Web.Tests/WebApplicationFactory.cs
@@ -9,11 +9,13 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using System.Threading;
 
 namespace EssentialCSharp.Web.Tests;
 
 public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
 {
+    private static readonly SemaphoreSlim SchemaInitializationGate = new(1, 1);
     // One GUID per factory instance → each factory gets its own isolated in-memory database.
     private readonly string _sqlConnectionString =
         $"DataSource=file:{Guid.NewGuid():N}?mode=memory&cache=shared";
@@ -129,10 +131,18 @@ public sealed class WebApplicationFactory : TestWebApplicationFactory<Program>
     {
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            using IServiceScope scope = serviceProvider.CreateScope();
-            EssentialCSharpWebContext dbContext =
-                scope.ServiceProvider.GetRequiredService<EssentialCSharpWebContext>();
-            await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+            await SchemaInitializationGate.WaitAsync(cancellationToken);
+            try
+            {
+                using IServiceScope scope = serviceProvider.CreateScope();
+                EssentialCSharpWebContext dbContext =
+                    scope.ServiceProvider.GetRequiredService<EssentialCSharpWebContext>();
+                await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+            }
+            finally
+            {
+                SchemaInitializationGate.Release();
+            }
         }
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;


### PR DESCRIPTION
## Summary
Migrates `EssentialCSharp.Web.Tests` to `TUnit.AspNetCore` using `WebApplicationTest<WebApplicationFactory, Program>` and `TestWebApplicationFactory<Program>`.

## What changed
- Added `TUnit.AspNetCore` package.
- Introduced `IntegrationTestBase` with shared `InServiceScope` helpers.
- Migrated integration-style test classes off `[ClassDataSource]` / constructor factory injection to `IntegrationTestBase` inheritance.
- Consolidated MCP rate-limiting tests into one class while keeping per-test host isolation.
- `McpTestHelper` now accepts `TracedWebApplicationFactory<Program>` and creates clients with explicit `AllowAutoRedirect = false` where redirect assertions require it.

## Current implementation details
- `WebApplicationFactory` stores a per-instance GUID-based SQLite connection string. A `_keepAliveConnection` is held open for the factory lifetime to keep the shared-cache in-memory database alive. `DbConnection` is registered as **scoped** so each request scope gets its own `SqliteConnection`, avoiding concurrent-access locking from sharing a single connection instance.
- Test schema creation runs through `EnsureCreatedHostedService`, registered at index `0` in the service collection so hosted-service startup runs schema creation first.
- Schema creation is serialized per factory instance to prevent concurrent `EnsureCreatedAsync()` races in CI.
- Functional tests use `GetFollowingGetRedirectsAsync` (GET-only redirect helper) and non-auto-redirect clients where status/location assertions depend on raw redirect responses.

## Notes
- This PR no longer uses `ConcurrentBag<SqliteConnection>`, `Interlocked` disposal guards, or `CreateRedirectFollowingClient()`.
- Build compiles cleanly after these updates.