### PR TITLE
ci: fix Docker GHA caching and add merge_group trigger

### DIFF
--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -63,17 +63,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # Build but no push with a PR
-      - name: Docker build (no push)
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        uses: docker/build-push-action@v7
-        with:
-          push: false
-          tags: temp-pr-validation
-          file: ./EssentialCSharp.Web/Dockerfile
-          context: .
-          build-args: ACCESS_TO_NUGET_FEED=false
-
       # Only build for dev registry — prod gets the image via az acr import in deploy-production
       - name: Build Container Image
         if: github.event_name != 'pull_request_target' && github.event_name != 'pull_request'

--- a/.github/workflows/PR-Build-And-Test.yml
+++ b/.github/workflows/PR-Build-And-Test.yml
@@ -3,6 +3,7 @@ name: PR Build and Test EssentialCSharp.Web
 on:
   pull_request:
     branches: ["main"]
+  merge_group:
   workflow_dispatch:
 
 jobs:
@@ -67,7 +68,7 @@ jobs:
         with:
           file: ./EssentialCSharp.Web/Dockerfile
           context: .
-          outputs: type=docker,dest=${{ github.workspace }}/essentialcsharpwebimage.tar
+          push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: ACCESS_TO_NUGET_FEED=false


### PR DESCRIPTION
## Summary

Docker GHA caching (`type=gha`) was already in both CI workflows, but three issues made it less effective than it should be.

## Changes

### `PR-Build-And-Test.yml`

**Add `merge_group` trigger**

Docker validation and tests were not running in the GitHub merge queue, meaning a merge could pass without a final Docker build check. Adding `merge_group:` ensures the same validation that runs on PRs also runs before merge.

**Replace tar export with `push: false`**

The Docker step was exporting the image to a `.tar` file (`outputs: type=docker,dest=...`) but that file was never uploaded as an artifact and never used by any downstream job. Exporting to a tar forces BuildKit to fully extract all image layers to disk — adding unnecessary time and disk I/O. Replacing it with `push: false` skips the extraction while still writing all layers to the GHA cache.

### `Build-Test-And-Deploy.yml`

**Remove dead "Docker build (no push)" step**

The step had this condition:
```yaml
if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
```
But this workflow only triggers on `push: branches: [main]` and `workflow_dispatch` — so that condition can never be true. The step was dead code. PR and merge_group Docker validation is now correctly owned by `PR-Build-And-Test.yml` (via the `merge_group` trigger added above).

## Before / After

| Workflow | Before | After |
|---|---|---|
| PR Docker build | Exports unused tar, no merge queue coverage | `push: false`, runs on merge queue too |
| Main Docker build | Has unreachable dead step | Dead step removed; caching unchanged |