### PR TITLE
feat: redirect www.essentialcsharp.com to apex domain

### DIFF
--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -1,10 +1,12 @@
 using System.Security.Claims;
 using System.Text.Json;
 using EssentialCSharp.Chat.Common.Services;
+using EssentialCSharp.Web.Models;
 using EssentialCSharp.Web.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Controllers;
 
@@ -17,13 +19,38 @@ public partial class ChatController : ControllerBase
 {
     private readonly AIChatService _AiChatService;
     private readonly ResponseIdValidationService _ResponseIdValidationService;
+    private readonly ICaptchaService _CaptchaService;
+    private readonly CaptchaOptions _CaptchaOptions;
     private readonly ILogger<ChatController> _Logger;
 
-    public ChatController(ILogger<ChatController> logger, AIChatService aiChatService, ResponseIdValidationService responseIdValidationService)
+    public ChatController(ILogger<ChatController> logger, AIChatService aiChatService,
+        ResponseIdValidationService responseIdValidationService,
+        ICaptchaService captchaService, IOptions<CaptchaOptions> captchaOptions)
     {
         _AiChatService = aiChatService;
         _ResponseIdValidationService = responseIdValidationService;
+        _CaptchaService = captchaService;
+        _CaptchaOptions = captchaOptions.Value;
         _Logger = logger;
+    }
+
+    /// <summary>
+    /// Validates the hCaptcha token when captcha is configured.
+    /// Returns <c>true</c> when captcha is not configured (dev mode) or when the token is valid.
+    /// Fails open on hCaptcha service outages to avoid blocking legitimate users.
+    /// </summary>
+    private async Task<bool> IsCaptchaValidAsync(string? token, string? remoteIp, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(_CaptchaOptions.SecretKey))
+            return true; // captcha not configured — skip validation
+
+        HCaptchaResult? result = await _CaptchaService.VerifyAsync(token, remoteIp, ct);
+        if (result is null)
+        {
+            LogCaptchaServiceUnavailable(_Logger); // hCaptcha unreachable — fail open
+            return true;
+        }
+        return result.Success;
     }
 
     [HttpPost("message")]
@@ -36,6 +63,9 @@ public partial class ChatController : ControllerBase
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(userId))
             return Unauthorized();
+
+        if (!await IsCaptchaValidAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken))
+            return StatusCode(403, new { error = "Human verification required.", errorCode = "captcha_failed" });
 
         var previousResponseId = string.IsNullOrWhiteSpace(request.PreviousResponseId)
             ? null
@@ -84,6 +114,13 @@ public partial class ChatController : ControllerBase
         {
             Response.StatusCode = 401;
             await Response.WriteAsJsonAsync(new { error = "Unauthorized." }, CancellationToken.None);
+            return;
+        }
+
+        if (!await IsCaptchaValidAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken))
+        {
+            Response.StatusCode = 403;
+            await Response.WriteAsJsonAsync(new { error = "Human verification required.", errorCode = "captcha_failed" }, CancellationToken.None);
             return;
         }
 
@@ -183,6 +220,9 @@ public partial class ChatController : ControllerBase
             }
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "hCaptcha service unavailable during chat request — failing open")]
+    private static partial void LogCaptchaServiceUnavailable(ILogger<ChatController> logger);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Chat stream cancelled for user {User}")]
     private static partial void LogChatStreamCancelled(ILogger<ChatController> logger, string? user);

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -37,18 +37,27 @@ public partial class ChatController : ControllerBase
     /// <summary>
     /// Validates the hCaptcha token when captcha is configured.
     /// Returns <c>true</c> when captcha is not configured (dev mode) or when the token is valid.
-    /// Fails open on hCaptcha service outages to avoid blocking legitimate users.
+    /// Fails open on hCaptcha service outages (null result) to avoid blocking legitimate users —
+    /// this is intentional given the existing [Authorize] + rate-limiting backstop.
     /// </summary>
     private async Task<bool> IsCaptchaValidAsync(string? token, string? remoteIp, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(_CaptchaOptions.SecretKey))
             return true; // captcha not configured — skip validation
 
+        if (string.IsNullOrWhiteSpace(token))
+            return false; // token required when captcha is configured — reject without an outbound call
+
         HCaptchaResult? result = await _CaptchaService.VerifyAsync(token, remoteIp, ct);
         if (result is null)
         {
-            LogCaptchaServiceUnavailable(_Logger); // hCaptcha unreachable — fail open
+            LogCaptchaServiceUnavailable(_Logger); // hCaptcha unreachable — fail open (intentional)
             return true;
+        }
+
+        if (!result.Success)
+        {
+            LogCaptchaValidationFailed(_Logger, string.Join(',', result.ErrorCodes ?? []));
         }
         return result.Success;
     }
@@ -223,6 +232,9 @@ public partial class ChatController : ControllerBase
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "hCaptcha service unavailable during chat request — failing open")]
     private static partial void LogCaptchaServiceUnavailable(ILogger<ChatController> logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "hCaptcha validation failed for chat request — error codes: {ErrorCodes}")]
+    private static partial void LogCaptchaValidationFailed(ILogger<ChatController> logger, string errorCodes);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Chat stream cancelled for user {User}")]
     private static partial void LogChatStreamCancelled(ILogger<ChatController> logger, string? user);

--- a/EssentialCSharp.Web/Controllers/ChatMessageRequest.cs
+++ b/EssentialCSharp.Web/Controllers/ChatMessageRequest.cs
@@ -10,5 +10,4 @@ public class ChatMessageRequest
     [StringLength(200)]
     public string? PreviousResponseId { get; set; }
     public bool EnableContextualSearch { get; set; } = true;
-    public string? CaptchaResponse { get; set; } // hCaptcha token; validated server-side when chat captcha enforcement is wired up
 }

--- a/EssentialCSharp.Web/Controllers/ChatMessageRequest.cs
+++ b/EssentialCSharp.Web/Controllers/ChatMessageRequest.cs
@@ -10,5 +10,5 @@ public class ChatMessageRequest
     [StringLength(200)]
     public string? PreviousResponseId { get; set; }
     public bool EnableContextualSearch { get; set; } = true;
-    public string? CaptchaResponse { get; set; } // For future captcha implementation
+    public string? CaptchaResponse { get; set; } // hCaptcha token; validated server-side when chat captcha enforcement is wired up
 }

--- a/EssentialCSharp.Web/Controllers/ChatMessageRequest.cs
+++ b/EssentialCSharp.Web/Controllers/ChatMessageRequest.cs
@@ -10,4 +10,10 @@ public class ChatMessageRequest
     [StringLength(200)]
     public string? PreviousResponseId { get; set; }
     public bool EnableContextualSearch { get; set; } = true;
+    /// <summary>
+    /// hCaptcha token obtained from the client-side invisible widget.
+    /// Required when <c>CaptchaOptions.SecretKey</c> is configured; ignored otherwise.
+    /// </summary>
+    [StringLength(2000)]
+    public string? CaptchaResponse { get; set; }
 }

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -112,11 +112,23 @@ public partial class Program
             options.ForwardedHeaders =
                 ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
 
-            // Only loopback proxies are allowed by default.
-            // Clear that restriction because forwarders are enabled by explicit 
-            // configuration.
             options.KnownIPNetworks.Clear();
             options.KnownProxies.Clear();
+
+            // Restrict trusted proxy sources to configured CIDRs.
+            // SECURITY: Set ForwardedHeaders:TrustedProxyCidrs in production to your
+            // load-balancer IP range (e.g., the Azure Container Apps ingress CIDR) to
+            // prevent X-Forwarded-For spoofing. Without this, any client can fabricate
+            // a forwarded IP and bypass IP-partitioned rate limits.
+            var trustedCidrs = builder.Configuration
+                .GetSection("ForwardedHeaders:TrustedProxyCidrs")
+                .Get<string[]>() ?? [];
+
+            foreach (var cidr in trustedCidrs)
+            {
+                if (System.Net.IPNetwork.TryParse(cidr, out var network))
+                    options.KnownIPNetworks.Add(network);
+            }
         });
 
         ConfigurationManager configuration = builder.Configuration;
@@ -326,7 +338,7 @@ public partial class Program
             {
                 // Partitioned per-user (when authenticated) or per-IP (anonymous)
                 var partitionKey = httpContext.User.Identity?.IsAuthenticated == true
-                    ? $"chat-user:{httpContext.User.Identity.Name ?? "unknown-user"}"
+                    ? $"chat-user:{httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown-user"}"
                     : $"chat-ip:{httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip"}";
 
                 return RateLimitPartition.GetFixedWindowLimiter(
@@ -363,7 +375,6 @@ public partial class Program
                     Dictionary<string, object> errorResponse = new()
                     {
                         ["error"] = "Rate limit exceeded. Please wait before sending another message.",
-                        ["requiresCaptcha"] = true,
                         ["statusCode"] = 429
                     };
                     if (retryAfterSeconds is int retryAfter)

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -515,6 +515,20 @@ public partial class Program
             app.UseSecurityHeadersMiddleware(new SecurityHeadersBuilder()
                 .AddDefaultSecurePolicy()
                 .AddContentSecurityPolicy(csp));
+
+            // Redirect www.essentialcsharp.com → essentialcsharp.com (permanent 301)
+            // Must be after UseForwardedHeaders so the Host header reflects the real hostname.
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Host.Host.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+                {
+                    string apexHost = context.Request.Host.Host[4..];
+                    string redirectUrl = $"{context.Request.Scheme}://{apexHost}{context.Request.PathBase}{context.Request.Path}{context.Request.QueryString}";
+                    context.Response.Redirect(redirectUrl, permanent: true);
+                    return;
+                }
+                await next(context);
+            });
         }
         else
         {

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -128,6 +128,8 @@ public partial class Program
             {
                 if (System.Net.IPNetwork.TryParse(cidr, out var network))
                     options.KnownIPNetworks.Add(network);
+                else
+                    Console.Error.WriteLine($"[WARN] ForwardedHeaders:TrustedProxyCidrs: could not parse '{cidr}' as an IP network — entry skipped. Check your configuration.");
             }
         });
 
@@ -320,7 +322,7 @@ public partial class Program
                     return RateLimitPartition.GetNoLimiter("mcp-transport");
 
                 var partitionKey = httpContext.User.Identity?.IsAuthenticated == true
-                    ? httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "unknown-user"
+                    ? httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown-user"
                     : httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip";
 
                 return RateLimitPartition.GetFixedWindowLimiter(
@@ -436,6 +438,16 @@ public partial class Program
         loggerFactory.Dispose();
 
         WebApplication app = builder.Build();
+
+        // Warn if the effective trusted-proxy set is empty in non-Development — this fires for
+        // both "no CIDRs configured" and "all configured CIDRs failed to parse" cases, ensuring
+        // X-Forwarded-For spoofing protection (F4) is visibly inactive until properly configured.
+        if (!app.Environment.IsDevelopment())
+        {
+            var fwdOpts = app.Services.GetRequiredService<IOptions<ForwardedHeadersOptions>>().Value;
+            if (fwdOpts.KnownIPNetworks.Count == 0 && fwdOpts.KnownProxies.Count == 0)
+                LogTrustedProxyCidrsNotConfigured(app.Logger);
+        }
 
         // Configure the HTTP request pipeline.
         if (!app.Environment.IsDevelopment())
@@ -623,4 +635,7 @@ public partial class Program
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Ignoring invalid TryDotNet origin in CSP: {Origin}")]
     private static partial void LogIgnoringInvalidTryDotNetOrigin(ILogger logger, string origin);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SECURITY: ForwardedHeaders:TrustedProxyCidrs is not configured. All X-Forwarded-For values are trusted, enabling IP spoofing against rate limits. Set this to your load-balancer CIDR (e.g., Azure Container Apps ingress range) to harden this endpoint.")]
+    private static partial void LogTrustedProxyCidrsNotConfigured(ILogger logger);
 }

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -609,7 +609,7 @@ public partial class Program
             SitemapXmlHelpers.EnsureSitemapHealthy(siteMappingService.SiteMappings.ToList());
             LogSitemapValidationSucceeded(logger);
         }
-        catch (Exception ex)
+        catch (InvalidOperationException ex)
         {
             LogSitemapValidationFailed(logger, ex);
             // Continue startup even if sitemap validation fails

--- a/EssentialCSharp.Web/Services/ContentRateLimiterPolicy.cs
+++ b/EssentialCSharp.Web/Services/ContentRateLimiterPolicy.cs
@@ -26,7 +26,7 @@ internal sealed class ContentRateLimiterPolicy : IRateLimiterPolicy<string>
         // Use stable user ID (GUID) for authenticated users so the bucket survives
         // username changes and doesn't conflate login/logout with scraping.
         string partitionKey = isAuthenticated
-            ? $"user:{httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? httpContext.User.Identity!.Name ?? "unknown"}"
+            ? $"user:{httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown-user"}"
             : $"ip:{httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip"}";
 
         int perMinuteLimit = isAuthenticated ? AuthenticatedPerMinute : AnonymousPerMinute;

--- a/EssentialCSharp.Web/Services/McpRateLimiterPolicy.cs
+++ b/EssentialCSharp.Web/Services/McpRateLimiterPolicy.cs
@@ -21,7 +21,6 @@ internal sealed partial class McpRateLimiterPolicy : IRateLimiterPolicy<string>
         if (httpContext.User.Identity?.IsAuthenticated == true)
         {
             string userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)
-                ?? httpContext.User.Identity?.Name
                 ?? "unknown-user";
 
             return RateLimitPartition.GetTokenBucketLimiter(

--- a/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
+++ b/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
@@ -6,9 +6,11 @@
 @using Microsoft.AspNetCore.Identity
 @using EssentialCSharp.Web.Areas.Identity.Data
 @using Microsoft.Extensions.Configuration
+@using Microsoft.Extensions.Options
 @inject ISiteMappingService _SiteMappings
 @inject SignInManager<EssentialCSharpWebUser> SignInManager
 @inject IConfiguration Configuration
+@inject IOptions<CaptchaOptions> _CaptchaOptions
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -192,6 +194,7 @@
         window.TRYDOTNET_ORIGIN = @Json.Serialize(Configuration["TryDotNet:Origin"]);
         window.BUILD_LABEL = @Json.Serialize(buildLabel);
         window.ENABLE_CHAT_WIDGET = @Json.Serialize(!Context.Request.Path.StartsWithSegments("/Identity"));
+        window.HCAPTCHA_SITE_KEY = @Json.Serialize(_CaptchaOptions.Value.SiteKey);
     </script>
     <script src="~/dist/assets/site-shell.js" type="module" asp-append-version="true"></script>
 </body>

--- a/EssentialCSharp.Web/appsettings.json
+++ b/EssentialCSharp.Web/appsettings.json
@@ -2,6 +2,9 @@
   "ConnectionStrings": {
     "PostgresVectorStore": "your-postgres-connection-string-here"
   },
+  "ForwardedHeaders": {
+    "TrustedProxyCidrs": []
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning",

--- a/EssentialCSharp.Web/src/components/ChatWidget.vue
+++ b/EssentialCSharp.Web/src/components/ChatWidget.vue
@@ -11,6 +11,7 @@ const {
     isTyping,
     chatMessagesEl,
     chatInputField,
+    captchaSiteKey,
     openChatDialog,
     closeChatDialog,
     clearChatHistory,
@@ -23,6 +24,18 @@ const {
 
 <template>
     <div class="chat-widget">
+        <!--
+            Invisible hCaptcha container: lives outside the v-if dialog so the widget
+            persists across open/close cycles and only needs to be initialized once.
+            Renders only when captcha is configured (HCAPTCHA_SITE_KEY is non-null).
+        -->
+        <div
+            v-if="captchaSiteKey"
+            id="chat-captcha-container"
+            class="visually-hidden"
+            aria-hidden="true"
+        />
+
         <button
             class="chat-button elevation-6"
             :class="{ 'chat-button--active': showChatDialog }"
@@ -189,6 +202,13 @@ const {
                             Type your question and press Enter or click send. Maximum 500 characters.
                         </div>
                     </form>
+                    <!-- hCaptcha legal disclosure required for invisible mode -->
+                    <p v-if="captchaSiteKey" class="captcha-notice small text-muted mt-1">
+                        Protected by hCaptcha —
+                        <a href="https://www.hcaptcha.com/privacy" target="_blank" rel="noopener noreferrer">Privacy</a>
+                        &amp;
+                        <a href="https://www.hcaptcha.com/terms" target="_blank" rel="noopener noreferrer">Terms</a>
+                    </p>
                 </div>
             </div>
         </div>

--- a/EssentialCSharp.Web/wwwroot/js/chat-module.js
+++ b/EssentialCSharp.Web/wwwroot/js/chat-module.js
@@ -18,6 +18,8 @@ const captchaSiteKey = window.HCAPTCHA_SITE_KEY || null;
 let captchaWidgetId = null;
 let captchaTokenResolve = null;
 let captchaTokenReject = null;
+let captchaPending = false; // prevents concurrent token requests overwriting promise callbacks
+const CAPTCHA_TIMEOUT_MS = 15_000;
 
 function initCaptchaWidget() {
     if (!captchaSiteKey) return;
@@ -56,17 +58,47 @@ function initCaptchaWidget() {
 /**
  * Returns a fresh hCaptcha token, or null if captcha is not configured.
  * Resolves after the invisible challenge completes (typically instant for non-suspicious users).
+ * Rejects with 'captcha-concurrent' if a token request is already in-flight.
+ * Rejects with 'captcha-timeout' if the widget does not respond within 15 seconds.
  */
 function getCaptchaToken() {
     if (!captchaSiteKey || captchaWidgetId === null) return Promise.resolve(null);
-    return new Promise((resolve, reject) => {
-        captchaTokenResolve = resolve;
-        captchaTokenReject = reject;
+    if (captchaPending) return Promise.reject(new Error('captcha-concurrent'));
+    captchaPending = true;
+
+    let timeoutId;
+
+    const tokenPromise = new Promise((resolve, reject) => {
+        captchaTokenResolve = (token) => {
+            captchaPending = false;
+            clearTimeout(timeoutId); // cancel lingering timer so it can't corrupt the next call
+            resolve(token);
+        };
+        captchaTokenReject  = (err) => {
+            captchaPending = false;
+            clearTimeout(timeoutId);
+            reject(err);
+        };
         window.hcaptcha.execute(captchaWidgetId);
     });
+
+    const timeoutPromise = new Promise((_, reject) => {
+        // timeoutId is assigned synchronously here, before captchaTokenResolve can fire
+        timeoutId = setTimeout(() => {
+            captchaPending = false;
+            captchaTokenResolve = null;
+            captchaTokenReject  = null;
+            reject(new Error('captcha-timeout'));
+        }, CAPTCHA_TIMEOUT_MS);
+    });
+
+    return Promise.race([tokenPromise, timeoutPromise]);
 }
 
 function resetCaptchaWidget() {
+    captchaPending = false;
+    captchaTokenResolve = null;
+    captchaTokenReject = null;
     if (captchaWidgetId !== null && typeof window.hcaptcha?.reset === 'function') {
         window.hcaptcha.reset(captchaWidgetId);
     }

--- a/EssentialCSharp.Web/wwwroot/js/chat-module.js
+++ b/EssentialCSharp.Web/wwwroot/js/chat-module.js
@@ -21,6 +21,13 @@ let captchaTokenReject = null;
 let captchaPending = false; // prevents concurrent token requests overwriting promise callbacks
 const CAPTCHA_TIMEOUT_MS = 15_000;
 
+// Resolves once the widget has rendered. getCaptchaToken() awaits this so a user who
+// submits before hCaptcha finishes loading waits (up to 15 s) rather than getting a 403.
+let captchaWidgetReadyResolve = null;
+const captchaWidgetReady = captchaSiteKey
+    ? new Promise((resolve) => { captchaWidgetReadyResolve = resolve; })
+    : Promise.resolve();
+
 function initCaptchaWidget() {
     if (!captchaSiteKey) return;
     // Guard: only render once (widget lives outside the v-if dialog overlay)
@@ -52,23 +59,26 @@ function initCaptchaWidget() {
                 reject?.(new Error('captcha-error'));
             }
         });
+        captchaWidgetReadyResolve?.(); // unblock any getCaptchaToken() calls waiting for the widget
     });
 }
 
 /**
  * Returns a fresh hCaptcha token, or null if captcha is not configured.
- * Resolves after the invisible challenge completes (typically instant for non-suspicious users).
+ * Waits for the widget to finish rendering if it has not yet (handles slow script loads).
  * Rejects with 'captcha-concurrent' if a token request is already in-flight.
  * Rejects with 'captcha-timeout' if the widget does not respond within 15 seconds.
  */
 function getCaptchaToken() {
-    if (!captchaSiteKey || captchaWidgetId === null) return Promise.resolve(null);
+    if (!captchaSiteKey) return Promise.resolve(null);
     if (captchaPending) return Promise.reject(new Error('captcha-concurrent'));
     captchaPending = true;
 
     let timeoutId;
 
-    const tokenPromise = new Promise((resolve, reject) => {
+    // Chain onto captchaWidgetReady so calls made before the widget finishes loading
+    // wait rather than immediately returning null and causing a 403.
+    const tokenPromise = captchaWidgetReady.then(() => new Promise((resolve, reject) => {
         captchaTokenResolve = (token) => {
             captchaPending = false;
             clearTimeout(timeoutId); // cancel lingering timer so it can't corrupt the next call
@@ -80,7 +90,7 @@ function getCaptchaToken() {
             reject(err);
         };
         window.hcaptcha.execute(captchaWidgetId);
-    });
+    }));
 
     const timeoutPromise = new Promise((_, reject) => {
         // timeoutId is assigned synchronously here, before captchaTokenResolve can fire

--- a/EssentialCSharp.Web/wwwroot/js/chat-module.js
+++ b/EssentialCSharp.Web/wwwroot/js/chat-module.js
@@ -6,10 +6,71 @@ import { ref, nextTick, watch, onMounted, onUnmounted } from "vue";
 const errorIconClassByType = {
     'rate-limit': 'fas fa-clock',
     'auth-error': 'fas fa-lock',
+    'captcha-error': 'fas fa-shield-alt',
     'validation-error': 'fas fa-exclamation-circle',
     'network-error': 'fas fa-wifi',
     'connection-error': 'fas fa-plug'
 };
+
+// hCaptcha integration — invisible widget renders once and is reused across messages.
+// When HCAPTCHA_SITE_KEY is null (dev / captcha not configured), all captcha calls are no-ops.
+const captchaSiteKey = window.HCAPTCHA_SITE_KEY || null;
+let captchaWidgetId = null;
+let captchaTokenResolve = null;
+let captchaTokenReject = null;
+
+function initCaptchaWidget() {
+    if (!captchaSiteKey) return;
+    // Guard: only render once (widget lives outside the v-if dialog overlay)
+    if (captchaWidgetId !== null) return;
+    const container = document.getElementById('chat-captcha-container');
+    if (!container) return;
+
+    window.EssentialCSharp.HCaptcha.whenHcaptchaReady(() => {
+        if (captchaWidgetId !== null) return; // double-check after async wait
+        captchaWidgetId = window.hcaptcha.render(container, {
+            sitekey: captchaSiteKey,
+            size: 'invisible',
+            callback: (token) => {
+                const resolve = captchaTokenResolve;
+                captchaTokenResolve = null;
+                captchaTokenReject = null;
+                resolve?.(token);
+            },
+            'expired-callback': () => {
+                const reject = captchaTokenReject;
+                captchaTokenResolve = null;
+                captchaTokenReject = null;
+                reject?.(new Error('captcha-expired'));
+            },
+            'error-callback': () => {
+                const reject = captchaTokenReject;
+                captchaTokenResolve = null;
+                captchaTokenReject = null;
+                reject?.(new Error('captcha-error'));
+            }
+        });
+    });
+}
+
+/**
+ * Returns a fresh hCaptcha token, or null if captcha is not configured.
+ * Resolves after the invisible challenge completes (typically instant for non-suspicious users).
+ */
+function getCaptchaToken() {
+    if (!captchaSiteKey || captchaWidgetId === null) return Promise.resolve(null);
+    return new Promise((resolve, reject) => {
+        captchaTokenResolve = resolve;
+        captchaTokenReject = reject;
+        window.hcaptcha.execute(captchaWidgetId);
+    });
+}
+
+function resetCaptchaWidget() {
+    if (captchaWidgetId !== null && typeof window.hcaptcha?.reset === 'function') {
+        window.hcaptcha.reset(captchaWidgetId);
+    }
+}
 
 export function useChatWidget() {
     // Authentication state
@@ -109,6 +170,7 @@ export function useChatWidget() {
                 chatInputField.value.focus();
             }
             scrollToBottom();
+            initCaptchaWidget();
         });
     }
 
@@ -212,10 +274,14 @@ export function useChatWidget() {
 
         let reader = null;
         try {
+            // Obtain invisible hCaptcha token (null when captcha is not configured)
+            const captchaResponse = await getCaptchaToken();
+
             const requestBody = {
                 message: userMessage,
                 enableContextualSearch: true,
-                previousResponseId: lastResponseId.value
+                previousResponseId: lastResponseId.value,
+                captchaResponse: captchaResponse
             };
 
             const response = await fetch('/api/chat/stream', {
@@ -229,6 +295,8 @@ export function useChatWidget() {
             if (!response.ok) {
                 if (response.status === 401) {
                     throw new Error('Authentication required');
+                } else if (response.status === 403) {
+                    throw new Error('captcha-failed: Human verification failed. Please try again.');
                 } else if (response.status === 429) {
                     // Handle rate limiting - simple error message without captcha
                     let errorData;
@@ -330,6 +398,9 @@ export function useChatWidget() {
                 errorMessage = 'You must be logged in to use the chat feature. Please log in and try again.';
                 errorType = 'auth-error';
                 isAuthenticated.value = false; // Update auth state
+            } else if (error.message?.startsWith('captcha-')) {
+                errorMessage = 'Human verification failed. Please try again.';
+                errorType = 'captcha-error';
             } else if (error.message?.includes('Rate limit exceeded')) {
                 errorMessage = error.message; // Use the specific rate limit message with timing
                 errorType = 'rate-limit';
@@ -358,6 +429,9 @@ export function useChatWidget() {
                 }
             }
             
+            // Reset the captcha widget so a fresh token is obtained for the next message
+            resetCaptchaWidget();
+
             // Ensure typing indicator is hidden
             isTyping.value = false;
             
@@ -379,6 +453,7 @@ export function useChatWidget() {
         isTyping,
         chatMessagesEl,
         chatInputField,
+        captchaSiteKey,
 
         // Methods
         openChatDialog,


### PR DESCRIPTION
## Problem
\www.essentialcsharp.com\ currently returns a 404 (HTTP) or connection reset (HTTPS) because the Azure Container App doesn't handle the \www\ hostname.

## Solution
Adds a **301 permanent redirect** in the production middleware pipeline that strips the \www.\ prefix and redirects to the apex domain (\ssentialcsharp.com\).

### Key details
- **Production only** — the redirect is inside the \!IsDevelopment()\ block, so local dev is unaffected
- **After \UseForwardedHeaders\** — runs after the forwarded headers middleware so the real \Host\ header is available when behind the Azure Container Apps ingress proxy
- No new dependencies required

## Required Azure change (separate)
This middleware handles the redirect **once traffic arrives at the app**. For \www\ traffic to reach the app at all, \www.essentialcsharp.com\ must be added as a custom domain on the Azure Container App (which will also provision a managed TLS certificate for it).