### PR TITLE
feat: redirect www.essentialcsharp.com to apex domain

### DIFF
--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -430,6 +430,17 @@ public partial class Program
         // Configure the HTTP request pipeline.
         if (!app.Environment.IsDevelopment())
         {
+            SiteSettings siteSettings = app.Services.GetRequiredService<IOptions<SiteSettings>>().Value;
+            if (!Uri.TryCreate(siteSettings.BaseUrl, UriKind.Absolute, out Uri? configuredBaseUri))
+            {
+                throw new InvalidOperationException($"Invalid {SiteSettings.SectionName}:{nameof(SiteSettings.BaseUrl)} value: '{siteSettings.BaseUrl}'.");
+            }
+            string apexHost = configuredBaseUri.Host.StartsWith("www.", StringComparison.OrdinalIgnoreCase)
+                ? configuredBaseUri.Host[4..]
+                : configuredBaseUri.Host;
+            string wwwHost = $"www.{apexHost}";
+            string redirectAuthority = new UriBuilder(configuredBaseUri) { Host = apexHost }.Uri.GetLeftPart(UriPartial.Authority);
+
             app.UseExceptionHandler(exceptionApp =>
             {
                 exceptionApp.Run(async context =>
@@ -494,14 +505,13 @@ public partial class Program
                 .AddDefaultSecurePolicy()
                 .AddContentSecurityPolicy(csp));
 
-            // Redirect www.essentialcsharp.com → essentialcsharp.com (permanent 301)
+            // Redirect configured www host to configured apex host (permanent 301).
             // Must be after UseForwardedHeaders so the Host header reflects the real hostname.
             app.Use(async (context, next) =>
             {
-                if (context.Request.Host.Host.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(context.Request.Host.Host, wwwHost, StringComparison.OrdinalIgnoreCase))
                 {
-                    string apexHost = context.Request.Host.Host[4..];
-                    string redirectUrl = $"{context.Request.Scheme}://{apexHost}{context.Request.PathBase}{context.Request.Path}{context.Request.QueryString}";
+                    string redirectUrl = $"{redirectAuthority}{context.Request.PathBase}{context.Request.Path}{context.Request.QueryString}";
                     context.Response.Redirect(redirectUrl, permanent: true);
                     return;
                 }

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -493,6 +493,20 @@ public partial class Program
             app.UseSecurityHeadersMiddleware(new SecurityHeadersBuilder()
                 .AddDefaultSecurePolicy()
                 .AddContentSecurityPolicy(csp));
+
+            // Redirect www.essentialcsharp.com → essentialcsharp.com (permanent 301)
+            // Must be after UseForwardedHeaders so the Host header reflects the real hostname.
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Host.Host.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+                {
+                    string apexHost = context.Request.Host.Host[4..];
+                    string redirectUrl = $"{context.Request.Scheme}://{apexHost}{context.Request.PathBase}{context.Request.Path}{context.Request.QueryString}";
+                    context.Response.Redirect(redirectUrl, permanent: true);
+                    return;
+                }
+                await next(context);
+            });
         }
         else
         {


### PR DESCRIPTION
## Problem
\www.essentialcsharp.com\ currently returns a 404 (HTTP) or connection reset (HTTPS) because the Azure Container App doesn't handle the \www\ hostname.

## Solution
Adds a **301 permanent redirect** in the production middleware pipeline that strips the \www.\ prefix and redirects to the apex domain (\ssentialcsharp.com\).

### Key details
- **Production only** — inside the \!IsDevelopment()\ block, local dev is unaffected
- **After \UseForwardedHeaders\** — so the real \Host\ header is readable behind the ACA ingress proxy
- No new dependencies

## Required Azure change (separate)
\www.essentialcsharp.com\ must be bound as a custom domain on the Azure Container App so traffic reaches the app at all (Azure will also provision a managed TLS cert).