### PR TITLE
fix: Set default embedding max batch size to 1024

### DIFF
--- a/EssentialCSharp.Chat.Shared/Models/EmbeddingRetryOptions.cs
+++ b/EssentialCSharp.Chat.Shared/Models/EmbeddingRetryOptions.cs
@@ -39,7 +39,7 @@ public sealed class EmbeddingRetryOptions
     /// The service may adaptively downshift below this value when throttled.
     /// </summary>
     [Range(1, 2048)]
-    public int MaxEmbeddingBatchSize { get; set; } = 2048;
+    public int MaxEmbeddingBatchSize { get; set; } = 1024;
 
     /// <summary>
     /// Minimum delay between embedding API requests in milliseconds.

--- a/EssentialCSharp.Web/appsettings.json
+++ b/EssentialCSharp.Web/appsettings.json
@@ -25,7 +25,7 @@
       "MaxRetries": 5,
       "BaseDelayMs": 1000,
       "MaxDelayMs": 60000,
-      "MaxEmbeddingBatchSize": 2048,
+      "MaxEmbeddingBatchSize": 1024,
       "MinInterRequestDelayMs": 250,
       "BackoffMultiplier": 2.0,
       "MaxJitterFraction": 0.2


### PR DESCRIPTION
This change lowers the default embedding request batch size based on observed production-like logs under S0 throttling, where 2048 repeatedly hit 429 and 1024 progressed successfully.

## Changes
- `EmbeddingRetryOptions.MaxEmbeddingBatchSize` default: `2048` -> `1024`
- `AIOptions:EmbeddingRetry:MaxEmbeddingBatchSize` in `EssentialCSharp.Web/appsettings.json`: `2048` -> `1024`

## Why
Recent run data showed sustained retry exhaustion at 2048 and successful completion after adaptive downshift to 1024. Setting 1024 as the default improves out-of-the-box behavior under throttled tiers while preserving configurability.