### PR TITLE
Replace hCaptcha hostname security check with informational telemetry

### DIFF
--- a/EssentialCSharp.Web/Services/CaptchaOptions.cs
+++ b/EssentialCSharp.Web/Services/CaptchaOptions.cs
@@ -26,10 +26,4 @@ public class CaptchaOptions
     /// </summary>
     public string JavaScriptUrl { get; set; } = "https://js.hcaptcha.com/1/api.js";
 
-    /// <summary>
-    /// If set, the hostname returned in the hCaptcha siteverify response is compared against this value.
-    /// Set to null (default) to skip hostname validation — required when using test keys or in development.
-    /// In production, set to the canonical hostname (e.g., "essentialcsharp.com").
-    /// </summary>
-    public string? ExpectedHostname { get; set; }
 }

--- a/EssentialCSharp.Web/Services/CaptchaService.cs
+++ b/EssentialCSharp.Web/Services/CaptchaService.cs
@@ -4,10 +4,11 @@ using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Services;
 
-public partial class CaptchaService(IHttpClientFactory clientFactory, IOptions<CaptchaOptions> optionsAccessor, ILogger<CaptchaService> logger) : ICaptchaService
+public partial class CaptchaService(IHttpClientFactory clientFactory, IOptions<CaptchaOptions> optionsAccessor, IOptions<SiteSettings> siteSettingsAccessor, ILogger<CaptchaService> logger) : ICaptchaService
 {
     private IHttpClientFactory ClientFactory { get; } = clientFactory;
     private CaptchaOptions Options { get; } = optionsAccessor.Value;
+    private SiteSettings SiteSettings { get; } = siteSettingsAccessor.Value;
 
     // Explicit overload used by integration tests: https://docs.hcaptcha.com/#verify-the-user-response-server-side
     public async Task<HCaptchaResult?> VerifyAsync(string secret, string response, string sitekey, CancellationToken cancellationToken = default)
@@ -49,13 +50,12 @@ public partial class CaptchaService(IHttpClientFactory clientFactory, IOptions<C
 
         HCaptchaResult? result = await PostVerification(postData, cancellationToken);
 
-        if (result is { Success: true } && Options.ExpectedHostname is { Length: > 0 } expectedHostname)
+        if (result is { Success: true })
         {
-            if (!string.Equals(result.Hostname, expectedHostname, StringComparison.OrdinalIgnoreCase))
-            {
-                LogHostnameMismatch(logger, expectedHostname, result.Hostname);
-                result.Success = false;
-            }
+            string expectedHostname = Uri.TryCreate(SiteSettings.BaseUrl, UriKind.Absolute, out Uri? baseUri)
+                ? baseUri.Host
+                : SiteSettings.BaseUrl;
+            LogHostnameVerified(logger, result.Hostname, expectedHostname);
         }
 
         return result;
@@ -81,8 +81,8 @@ public partial class CaptchaService(IHttpClientFactory clientFactory, IOptions<C
         }
     }
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "hCaptcha hostname mismatch: expected {Expected}, got {Actual}")]
-    private static partial void LogHostnameMismatch(ILogger<CaptchaService> logger, string expected, string? actual);
+    [LoggerMessage(Level = LogLevel.Information, Message = "hCaptcha hostname: reported={ReportedHostname}, expected={ExpectedHostname}")]
+    private static partial void LogHostnameVerified(ILogger<CaptchaService> logger, string reportedHostname, string expectedHostname);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "hCaptcha siteverify request failed")]
     private static partial void LogSiteverifyFailed(ILogger<CaptchaService> logger, Exception exception);


### PR DESCRIPTION
## Why

The `ExpectedHostname` config in `CaptchaOptions` was being used to validate the `hostname` field returned by hCaptcha's siteverify API -- failing the captcha if it didn't match. However, [hCaptcha's own docs](https://docs.hcaptcha.com/#verify-the-user-response-server-side) explicitly state:

> "the hostname field is derived from the user's browser, and should not be used for authentication of any kind; it is primarily useful as a statistical metric. Additionally... the hostname field may be returned as 'not-provided' rather than the usual value"

This means the check provided false security (browser-controlled, trivially spoofable) and could silently reject legitimate users under high traffic when hCaptcha returns `"not-provided"`.

## What changed

- **`CaptchaOptions.cs`**: Removed `ExpectedHostname` property. The `HCaptcha__ExpectedHostname` environment variable can now be removed from all deployed environments.
- **`CaptchaService.cs`**: Replaced the hostname mismatch block (which set `result.Success = false`) with an informational log that fires on every successful verification. The expected hostname is now derived from `SiteSettings.BaseUrl` rather than a separate config value.

## Telemetry

Every successful captcha verification now logs:

```
hCaptcha hostname: reported={ReportedHostname}, expected={ExpectedHostname}
```

This enables App Insights / Log Analytics queries to bucket hostname distributions, for example:

```kql
traces
| where message startswith "hCaptcha hostname"
| extend reported = tostring(customDimensions.ReportedHostname),
         expected = tostring(customDimensions.ExpectedHostname)
| summarize count() by reported, expected
```