### PR TITLE
Share captcha validation policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ TestResults/
 
 # Old or generated files to not commit
 build_output.txt
+test_output.txt
 wwwroot/sitemap.xml
 wwwroot/Chapters
 EssentialCSharp.Web/wwwroot/Chapters

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,5 +62,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
     <PackageVersion Include="DotnetSitemapGenerator" Version="2.0.0" />
+    <PackageVersion Include="OpenAI" Version="2.10.0" />
   </ItemGroup>
 </Project>

--- a/EssentialCSharp.Chat.Shared/EssentialCSharp.Chat.Common.csproj
+++ b/EssentialCSharp.Chat.Shared/EssentialCSharp.Chat.Common.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
+    <PackageReference Include="OpenAI" />
     <PackageReference Include="Microsoft.SourceLink.GitHub">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/EssentialCSharp.Chat.Shared/Extensions/ServiceCollectionExtensions.cs
+++ b/EssentialCSharp.Chat.Shared/Extensions/ServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using EssentialCSharp.Chat.Common.Services;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
 using Npgsql;

--- a/EssentialCSharp.Web.Tests/CaptchaValidationServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/CaptchaValidationServiceTests.cs
@@ -1,0 +1,121 @@
+using EssentialCSharp.Web.Models;
+using EssentialCSharp.Web.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace EssentialCSharp.Web.Tests;
+
+public class CaptchaValidationServiceTests
+{
+    [Test]
+    public async Task ValidateAsync_Disabled_SkipsVerification()
+    {
+        StubCaptchaService captchaService = new((_, _, _) => throw new InvalidOperationException("Verifier should not be called."));
+        using ServiceProvider serviceProvider = CreateServiceProvider(
+            new CaptchaOptions { SecretKey = string.Empty, SiteKey = string.Empty },
+            captchaService);
+
+        ICaptchaValidationService validationService = serviceProvider.GetRequiredService<ICaptchaValidationService>();
+
+        CaptchaValidationResult result = await validationService.ValidateAsync("token", "127.0.0.1");
+
+        await Assert.That(result.Outcome).IsEqualTo(CaptchaValidationOutcome.Disabled);
+        await Assert.That(result.ShouldProceed).IsTrue();
+        await Assert.That(captchaService.CallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ValidateAsync_MissingToken_ReturnsMissingToken()
+    {
+        StubCaptchaService captchaService = new((_, _, _) => throw new InvalidOperationException("Verifier should not be called."));
+        using ServiceProvider serviceProvider = CreateServiceProvider(
+            new CaptchaOptions { SecretKey = "secret", SiteKey = "sitekey" },
+            captchaService);
+
+        ICaptchaValidationService validationService = serviceProvider.GetRequiredService<ICaptchaValidationService>();
+
+        CaptchaValidationResult result = await validationService.ValidateAsync(string.Empty, "127.0.0.1");
+
+        await Assert.That(result.Outcome).IsEqualTo(CaptchaValidationOutcome.MissingToken);
+        await Assert.That(result.ShouldProceed).IsFalse();
+        await Assert.That(captchaService.CallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ValidateAsync_Unavailable_ReturnsUnavailable()
+    {
+        StubCaptchaService captchaService = new((_, _, _) => Task.FromResult<HCaptchaResult?>(null));
+        using ServiceProvider serviceProvider = CreateServiceProvider(
+            new CaptchaOptions { SecretKey = "secret", SiteKey = "sitekey" },
+            captchaService);
+
+        ICaptchaValidationService validationService = serviceProvider.GetRequiredService<ICaptchaValidationService>();
+
+        CaptchaValidationResult result = await validationService.ValidateAsync("token", "127.0.0.1");
+
+        await Assert.That(result.Outcome).IsEqualTo(CaptchaValidationOutcome.Unavailable);
+        await Assert.That(result.ShouldProceed).IsFalse();
+        await Assert.That(captchaService.CallCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ValidateAsync_InvalidAndValid_ReturnExpectedOutcome()
+    {
+        StubCaptchaService invalidCaptchaService = new((_, _, _) => Task.FromResult<HCaptchaResult?>(new HCaptchaResult
+        {
+            Success = false,
+            ErrorCodes = ["invalid-input-response"]
+        }));
+        using ServiceProvider invalidProvider = CreateServiceProvider(
+            new CaptchaOptions { SecretKey = "secret", SiteKey = "sitekey" },
+            invalidCaptchaService);
+
+        ICaptchaValidationService invalidValidationService = invalidProvider.GetRequiredService<ICaptchaValidationService>();
+        CaptchaValidationResult invalidResult = await invalidValidationService.ValidateAsync("token", "127.0.0.1");
+
+        await Assert.That(invalidResult.Outcome).IsEqualTo(CaptchaValidationOutcome.Invalid);
+        await Assert.That(invalidResult.Response).IsNotNull();
+        await Assert.That(invalidResult.ShouldProceed).IsFalse();
+
+        StubCaptchaService validCaptchaService = new((_, _, _) => Task.FromResult<HCaptchaResult?>(new HCaptchaResult
+        {
+            Success = true
+        }));
+        using ServiceProvider validProvider = CreateServiceProvider(
+            new CaptchaOptions { SecretKey = "secret", SiteKey = "sitekey" },
+            validCaptchaService);
+
+        ICaptchaValidationService validValidationService = validProvider.GetRequiredService<ICaptchaValidationService>();
+        CaptchaValidationResult validResult = await validValidationService.ValidateAsync("token", "127.0.0.1");
+
+        await Assert.That(validResult.Outcome).IsEqualTo(CaptchaValidationOutcome.Valid);
+        await Assert.That(validResult.ShouldProceed).IsTrue();
+        await Assert.That(validCaptchaService.CallCount).IsEqualTo(1);
+    }
+
+    private static ServiceProvider CreateServiceProvider(CaptchaOptions options, ICaptchaService captchaService)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton(Options.Create(options));
+        services.AddSingleton(captchaService);
+        services.AddSingleton<ICaptchaValidationService, CaptchaValidationService>();
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class StubCaptchaService(Func<string?, string?, CancellationToken, Task<HCaptchaResult?>> verifyAsync) : ICaptchaService
+    {
+        public int CallCount { get; private set; }
+
+        public Task<HCaptchaResult?> VerifyAsync(string secret, string response, string sitekey, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<HCaptchaResult?> VerifyAsync(string? response, CancellationToken cancellationToken = default)
+            => VerifyAsync(response, remoteIp: null, cancellationToken);
+
+        public async Task<HCaptchaResult?> VerifyAsync(string? response, string? remoteIp, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return await verifyAsync(response, remoteIp, cancellationToken);
+        }
+    }
+}

--- a/EssentialCSharp.Web.Tests/CaptchaValidationServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/CaptchaValidationServiceTests.cs
@@ -106,9 +106,6 @@ public class CaptchaValidationServiceTests
     {
         public int CallCount { get; private set; }
 
-        public Task<HCaptchaResult?> VerifyAsync(string secret, string response, string sitekey, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
         public Task<HCaptchaResult?> VerifyAsync(string? response, CancellationToken cancellationToken = default)
             => VerifyAsync(response, remoteIp: null, cancellationToken);
 

--- a/EssentialCSharp.Web.Tests/CaptchaValidationServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/CaptchaValidationServiceTests.cs
@@ -8,7 +8,7 @@ namespace EssentialCSharp.Web.Tests;
 public class CaptchaValidationServiceTests
 {
     [Test]
-    public async Task ValidateAsync_Disabled_SkipsVerification()
+    public async Task ValidateAsync_MissingConfig_RejectsWithoutVerification()
     {
         StubCaptchaService captchaService = new((_, _, _) => throw new InvalidOperationException("Verifier should not be called."));
         using ServiceProvider serviceProvider = CreateServiceProvider(
@@ -20,7 +20,7 @@ public class CaptchaValidationServiceTests
         CaptchaValidationResult result = await validationService.ValidateAsync("token", "127.0.0.1");
 
         await Assert.That(result.Outcome).IsEqualTo(CaptchaValidationOutcome.Disabled);
-        await Assert.That(result.ShouldProceed).IsTrue();
+        await Assert.That(result.ShouldProceed).IsFalse();
         await Assert.That(captchaService.CallCount).IsEqualTo(0);
     }
 

--- a/EssentialCSharp.Web.Tests/CaptchaValidationServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/CaptchaValidationServiceTests.cs
@@ -25,6 +25,40 @@ public class CaptchaValidationServiceTests
     }
 
     [Test]
+    public async Task ValidateAsync_MissingSiteKey_RejectsWithoutVerification()
+    {
+        StubCaptchaService captchaService = new((_, _, _) => throw new InvalidOperationException("Verifier should not be called."));
+        using ServiceProvider serviceProvider = CreateServiceProvider(
+            new CaptchaOptions { SecretKey = "secret", SiteKey = string.Empty },
+            captchaService);
+
+        ICaptchaValidationService validationService = serviceProvider.GetRequiredService<ICaptchaValidationService>();
+
+        CaptchaValidationResult result = await validationService.ValidateAsync("token", "127.0.0.1");
+
+        await Assert.That(result.Outcome).IsEqualTo(CaptchaValidationOutcome.Disabled);
+        await Assert.That(result.ShouldProceed).IsFalse();
+        await Assert.That(captchaService.CallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ValidateAsync_MissingSecretKey_RejectsWithoutVerification()
+    {
+        StubCaptchaService captchaService = new((_, _, _) => throw new InvalidOperationException("Verifier should not be called."));
+        using ServiceProvider serviceProvider = CreateServiceProvider(
+            new CaptchaOptions { SecretKey = string.Empty, SiteKey = "sitekey" },
+            captchaService);
+
+        ICaptchaValidationService validationService = serviceProvider.GetRequiredService<ICaptchaValidationService>();
+
+        CaptchaValidationResult result = await validationService.ValidateAsync("token", "127.0.0.1");
+
+        await Assert.That(result.Outcome).IsEqualTo(CaptchaValidationOutcome.Disabled);
+        await Assert.That(result.ShouldProceed).IsFalse();
+        await Assert.That(captchaService.CallCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ValidateAsync_MissingToken_ReturnsMissingToken()
     {
         StubCaptchaService captchaService = new((_, _, _) => throw new InvalidOperationException("Verifier should not be called."));

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,8 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 using System.Text.Encodings.Web;
 using EssentialCSharp.Web.Areas.Identity.Data;
-using EssentialCSharp.Web.Models;
 using EssentialCSharp.Web.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
@@ -13,7 +12,7 @@ using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Areas.Identity.Pages.Account;
 
-public class ForgotPasswordModel(UserManager<EssentialCSharpWebUser> userManager, IEmailSender emailSender, ICaptchaService captchaService, IOptions<CaptchaOptions> optionsAccessor) : PageModel
+public class ForgotPasswordModel(UserManager<EssentialCSharpWebUser> userManager, IEmailSender emailSender, ICaptchaValidationService captchaValidationService, IOptions<CaptchaOptions> optionsAccessor) : PageModel
 {
     private InputModel? _Input;
     [BindProperty]
@@ -36,8 +35,8 @@ public class ForgotPasswordModel(UserManager<EssentialCSharpWebUser> userManager
     public async Task<IActionResult> OnPostAsync()
     {
         string? captchaToken = Request.Form[CaptchaOptions.HttpPostResponseKeyName];
-        HCaptchaResult? captchaResult = await captchaService.VerifyAsync(captchaToken, HttpContext.Connection.RemoteIpAddress?.ToString());
-        if (captchaResult?.Success != true)
+        CaptchaValidationResult captchaResult = await captchaValidationService.ValidateAsync(captchaToken, HttpContext.Connection.RemoteIpAddress?.ToString());
+        if (!captchaResult.ShouldProceed)
         {
             ModelState.AddModelError(string.Empty, "Human verification failed. Please try again.");
             return Page();

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -1,6 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using EssentialCSharp.Web.Areas.Identity.Data;
-using EssentialCSharp.Web.Models;
 using EssentialCSharp.Web.Services;
 using EssentialCSharp.Web.Services.Referrals;
 using Microsoft.AspNetCore.Authentication;
@@ -11,7 +10,7 @@ using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Areas.Identity.Pages.Account;
 
-public partial class LoginModel(SignInManager<EssentialCSharpWebUser> signInManager, UserManager<EssentialCSharpWebUser> userManager, ILogger<LoginModel> logger, IReferralService referralService, ICaptchaService captchaService, IOptions<CaptchaOptions> optionsAccessor) : PageModel
+public partial class LoginModel(SignInManager<EssentialCSharpWebUser> signInManager, UserManager<EssentialCSharpWebUser> userManager, ILogger<LoginModel> logger, IReferralService referralService, ICaptchaValidationService captchaValidationService, IOptions<CaptchaOptions> optionsAccessor) : PageModel
 {
     private InputModel? _Input;
     [BindProperty]
@@ -68,8 +67,8 @@ public partial class LoginModel(SignInManager<EssentialCSharpWebUser> signInMana
         returnUrl ??= Url.Content("~/");
 
         string? captchaToken = Request.Form[CaptchaOptions.HttpPostResponseKeyName];
-        HCaptchaResult? captchaResult = await captchaService.VerifyAsync(captchaToken, HttpContext.Connection.RemoteIpAddress?.ToString());
-        if (captchaResult?.Success != true)
+        CaptchaValidationResult captchaResult = await captchaValidationService.ValidateAsync(captchaToken, HttpContext.Connection.RemoteIpAddress?.ToString());
+        if (!captchaResult.ShouldProceed)
         {
             ModelState.AddModelError(string.Empty, "Human verification failed. Please try again.");
             ExternalLogins = (await signInManager.GetExternalAuthenticationSchemesAsync()).ToList();

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -92,6 +92,12 @@ public partial class RegisterModel(
         CaptchaValidationResult captchaResult = await captchaValidationService.ValidateAsync(hCaptcha_response, HttpContext.Connection.RemoteIpAddress?.ToString());
         if (!captchaResult.ShouldProceed)
         {
+            if (captchaResult.Outcome == CaptchaValidationOutcome.Disabled)
+            {
+                LogHCaptchaDisabledWarning(logger);
+                ModelState.AddModelError(string.Empty, "Captcha verification is not configured. Please contact support.");
+                return Page();
+            }
             if (captchaResult.Outcome == CaptchaValidationOutcome.MissingToken)
             {
                 ModelState.AddModelError(string.Empty, HCaptchaErrorDetails.GetValue(HCaptchaErrorDetails.MissingInputResponse).FriendlyDescription);
@@ -105,14 +111,7 @@ public partial class RegisterModel(
             if (captchaResult.Outcome == CaptchaValidationOutcome.Invalid)
             {
                 HCaptchaResult? response = captchaResult.Response;
-                // The JSON should also return a field "success" as true
-                // https://docs.hcaptcha.com/#verify-the-user-response-server-side
-                if (response is null)
-                {
-                    LogHCaptchaNullErrorCodes(logger);
-                    ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
-                    return Page();
-                }
+                ArgumentNullException.ThrowIfNull(response);
 
                 switch (response.ErrorCodes?.Length)
                 {
@@ -134,6 +133,13 @@ public partial class RegisterModel(
                             }
                             if (HCaptchaErrorDetails.TryGetValue(response.ErrorCodes.Single(), out HCaptchaErrorDetails? details))
                             {
+                                if (details is null)
+                                {
+                                    LogHCaptchaNullErrorCodes(logger);
+                                    ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
+                                    return Page();
+                                }
+
                                 switch (details.ErrorCode)
                                 {
                                     case HCaptchaErrorDetails.MissingInputResponse:
@@ -246,6 +252,9 @@ public partial class RegisterModel(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "User created a new account with password.")]
     private static partial void LogUserCreatedWithPassword(ILogger<RegisterModel> logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Captcha is disabled in configuration")]
+    private static partial void LogHCaptchaDisabledWarning(ILogger<RegisterModel> logger);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "HCaptcha determined the passcode is not valid with zero error codes")]
     private static partial void LogHCaptchaNoErrorCodes(ILogger<RegisterModel> logger);

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -110,8 +110,12 @@ public partial class RegisterModel(
             }
             if (captchaResult.Outcome == CaptchaValidationOutcome.Invalid)
             {
-                HCaptchaResult? response = captchaResult.Response;
-                ArgumentNullException.ThrowIfNull(response);
+                if (captchaResult.Response is not HCaptchaResult response)
+                {
+                    LogHCaptchaInvalidOutcomeMissingResponse(logger);
+                    ModelState.AddModelError(string.Empty, "Captcha verification is temporarily unavailable. Please try again later.");
+                    return Page();
+                }
 
                 switch (response.ErrorCodes?.Length)
                 {
@@ -160,7 +164,7 @@ public partial class RegisterModel(
                                         ModelState.AddModelError(string.Empty, "Captcha verification is temporarily unavailable. Please try again later.");
                                         return Page();
                                     default:
-                                        LogHCaptchaUnknownErrorCode(logger, details?.ErrorCode);
+                                        LogHCaptchaUnknownErrorCode(logger, details.ErrorCode);
                                         ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
                                         return Page();
                                 }
@@ -172,6 +176,10 @@ public partial class RegisterModel(
                         }
                 }
             }
+
+            LogHCaptchaUnhandledOutcome(logger, captchaResult.Outcome.ToString());
+            ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
+            return Page();
         }
 
         EssentialCSharpWebUser user = CreateUser();
@@ -276,4 +284,10 @@ public partial class RegisterModel(
 
     [LoggerMessage(Level = LogLevel.Error, Message = "HCaptcha returned unrecognized error code: {ErrorCode}")]
     private static partial void LogHCaptchaUnrecognizedErrorCode(ILogger<RegisterModel> logger, string errorCode);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "HCaptcha invalid outcome did not include response payload")]
+    private static partial void LogHCaptchaInvalidOutcomeMissingResponse(ILogger<RegisterModel> logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "HCaptcha returned unhandled non-proceeding outcome: {Outcome}")]
+    private static partial void LogHCaptchaUnhandledOutcome(ILogger<RegisterModel> logger, string outcome);
 }

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -167,6 +167,7 @@ public partial class RegisterModel(
                 }
             }
 
+            ModelState.AddModelError(string.Empty, "Captcha verification is temporarily unavailable. Please try again later.");
             return Page();
         }
 

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -166,9 +166,7 @@ public partial class RegisterModel(
                         }
                 }
             }
-
-            ModelState.AddModelError(string.Empty, "Captcha verification is temporarily unavailable. Please try again later.");
-            return Page();
+        }
 
         EssentialCSharpWebUser user = CreateUser();
         user.FirstName = Input.FirstName;

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -20,7 +20,7 @@ public partial class RegisterModel(
     SignInManager<EssentialCSharpWebUser> signInManager,
     ILogger<RegisterModel> logger,
     IEmailSender emailSender,
-    ICaptchaService captchaService,
+    ICaptchaValidationService captchaValidationService,
     IOptions<CaptchaOptions> optionsAccessor,
     IUserEmailStore<EssentialCSharpWebUser> emailStore) : PageModel
 {
@@ -89,135 +89,140 @@ public partial class RegisterModel(
             return Page();
         }
 
-        if (string.IsNullOrEmpty(hCaptcha_response))
+        CaptchaValidationResult captchaResult = await captchaValidationService.ValidateAsync(hCaptcha_response, HttpContext.Connection.RemoteIpAddress?.ToString());
+        if (!captchaResult.ShouldProceed)
         {
-            ModelState.AddModelError(string.Empty, HCaptchaErrorDetails.GetValue(HCaptchaErrorDetails.MissingInputResponse).FriendlyDescription);
-            return Page();
-        }
-
-        HCaptchaResult? response = await captchaService.VerifyAsync(hCaptcha_response, HttpContext.Connection.RemoteIpAddress?.ToString());
-        if (response is null)
-        {
-            ModelState.AddModelError(string.Empty, "Captcha verification is temporarily unavailable. Please try again later.");
-            return Page();
-        }
-
-        // The JSON should also return a field "success" as true
-        // https://docs.hcaptcha.com/#verify-the-user-response-server-side
-        if (response.Success)
-        {
-            EssentialCSharpWebUser user = CreateUser();
-            user.FirstName = Input.FirstName;
-            user.LastName = Input.LastName;
-
-            await userStore.SetUserNameAsync(user, Input.UserName, CancellationToken.None);
-            await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
-            if (Input.Password is null)
+            if (captchaResult.Outcome == CaptchaValidationOutcome.MissingToken)
             {
-                LogPasswordNull(logger);
-                ModelState.AddModelError(string.Empty, "Error: Password null; please enter in a password");
+                ModelState.AddModelError(string.Empty, HCaptchaErrorDetails.GetValue(HCaptchaErrorDetails.MissingInputResponse).FriendlyDescription);
                 return Page();
             }
-            IdentityResult result = await userManager.CreateAsync(user, Input.Password);
-
-            if (result.Succeeded)
+            if (captchaResult.Outcome == CaptchaValidationOutcome.Unavailable)
             {
-                LogUserCreatedWithPassword(logger);
-
-                string userId = await userManager.GetUserIdAsync(user);
-                string code = await userManager.GenerateEmailConfirmationTokenAsync(user);
-                code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
-                string? callbackUrl = Url.Page(
-                    "/Account/ConfirmEmail",
-                    pageHandler: null,
-                    values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
-                    protocol: Request.Scheme);
-
-                if (callbackUrl is null)
+                ModelState.AddModelError(string.Empty, "Captcha verification is temporarily unavailable. Please try again later.");
+                return Page();
+            }
+            if (captchaResult.Outcome == CaptchaValidationOutcome.Invalid)
+            {
+                HCaptchaResult? response = captchaResult.Response;
+                // The JSON should also return a field "success" as true
+                // https://docs.hcaptcha.com/#verify-the-user-response-server-side
+                if (response is null)
                 {
-                    ModelState.AddModelError(string.Empty, "Error: callback url unexpectedly null.");
+                    LogHCaptchaNullErrorCodes(logger);
+                    ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
                     return Page();
                 }
-                if (Input.Email is null)
-                {
-                    ModelState.AddModelError(string.Empty, "Error: Email may not be null.");
-                    return Page();
-                }
-                await emailSender.SendEmailAsync(Input.Email, "Confirm your email",
-                    $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
 
-                if (userManager.Options.SignIn.RequireConfirmedAccount)
+                switch (response.ErrorCodes?.Length)
                 {
-                    return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
-                }
-                else
-                {
-                    await signInManager.SignInAsync(user, isPersistent: false);
-                    return LocalRedirect(returnUrl);
-                }
-            }
-            foreach (IdentityError error in result.Errors)
-            {
-                ModelState.AddModelError(string.Empty, error.Description);
-            }
-        }
-        else
-        {
-            switch (response.ErrorCodes?.Length)
-            {
-                case 0:
-                    LogHCaptchaNoErrorCodes(logger);
-                    ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
-                    break;
-                case > 1:
-                    LogHCaptchaMultipleErrorCodes(logger, string.Join(", ", response.ErrorCodes));
-                    ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
-                    break;
-                default:
-                    {
-                        if (response.ErrorCodes is null)
+                    case 0:
+                        LogHCaptchaNoErrorCodes(logger);
+                        ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
+                        return Page();
+                    case > 1:
+                        LogHCaptchaMultipleErrorCodes(logger, string.Join(", ", response.ErrorCodes));
+                        ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
+                        return Page();
+                    default:
                         {
-                            LogHCaptchaNullErrorCodes(logger);
-                            ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
-                            break;
-                        }
-                        if (HCaptchaErrorDetails.TryGetValue(response.ErrorCodes.Single(), out HCaptchaErrorDetails? details))
-                        {
-                            switch (details.ErrorCode)
+                            if (response.ErrorCodes is null)
                             {
-                                case HCaptchaErrorDetails.MissingInputResponse:
-                                case HCaptchaErrorDetails.InvalidInputResponse:
-                                case HCaptchaErrorDetails.InvalidOrAlreadySeenResponse:
-                                    ModelState.AddModelError(string.Empty, details.FriendlyDescription);
-                                    LogHCaptchaErrorCode(logger, details.ToString());
-                                    break;
-                                case HCaptchaErrorDetails.BadRequest:
-                                    ModelState.AddModelError(string.Empty, details.FriendlyDescription);
-                                    LogHCaptchaErrorCode(logger, details.ToString());
-                                    break;
-                                case HCaptchaErrorDetails.MissingInputSecret:
-                                case HCaptchaErrorDetails.InvalidInputSecret:
-                                case HCaptchaErrorDetails.NotUsingDummyPasscode:
-                                case HCaptchaErrorDetails.SitekeySecretMismatch:
-                                    LogHCaptchaCriticalErrorCode(logger, details.ToString());
-                                    ModelState.AddModelError(string.Empty, "Captcha verification is temporarily unavailable. Please try again later.");
-                                    break;
-                                default:
-                                    LogHCaptchaUnknownErrorCode(logger, details?.ErrorCode);
-                                    ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
-                                    break;
+                                LogHCaptchaNullErrorCodes(logger);
+                                ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
+                                return Page();
                             }
-                        }
-                        else
-                        {
+                            if (HCaptchaErrorDetails.TryGetValue(response.ErrorCodes.Single(), out HCaptchaErrorDetails? details))
+                            {
+                                switch (details.ErrorCode)
+                                {
+                                    case HCaptchaErrorDetails.MissingInputResponse:
+                                    case HCaptchaErrorDetails.InvalidInputResponse:
+                                    case HCaptchaErrorDetails.InvalidOrAlreadySeenResponse:
+                                        ModelState.AddModelError(string.Empty, details.FriendlyDescription);
+                                        LogHCaptchaErrorCode(logger, details.ToString());
+                                        return Page();
+                                    case HCaptchaErrorDetails.BadRequest:
+                                        ModelState.AddModelError(string.Empty, details.FriendlyDescription);
+                                        LogHCaptchaErrorCode(logger, details.ToString());
+                                        return Page();
+                                    case HCaptchaErrorDetails.MissingInputSecret:
+                                    case HCaptchaErrorDetails.InvalidInputSecret:
+                                    case HCaptchaErrorDetails.NotUsingDummyPasscode:
+                                    case HCaptchaErrorDetails.SitekeySecretMismatch:
+                                        LogHCaptchaCriticalErrorCode(logger, details.ToString());
+                                        ModelState.AddModelError(string.Empty, "Captcha verification is temporarily unavailable. Please try again later.");
+                                        return Page();
+                                    default:
+                                        LogHCaptchaUnknownErrorCode(logger, details?.ErrorCode);
+                                        ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
+                                        return Page();
+                                }
+                            }
+
                             LogHCaptchaUnrecognizedErrorCode(logger, response.ErrorCodes.Single());
                             ModelState.AddModelError(string.Empty, "Captcha verification failed. Please try again.");
+                            return Page();
                         }
-
-                        break;
-                    }
-
+                }
             }
+
+            return Page();
+        }
+
+        EssentialCSharpWebUser user = CreateUser();
+        user.FirstName = Input.FirstName;
+        user.LastName = Input.LastName;
+
+        await userStore.SetUserNameAsync(user, Input.UserName, CancellationToken.None);
+        await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+        if (Input.Password is null)
+        {
+            LogPasswordNull(logger);
+            ModelState.AddModelError(string.Empty, "Error: Password null; please enter in a password");
+            return Page();
+        }
+        IdentityResult result = await userManager.CreateAsync(user, Input.Password);
+
+        if (result.Succeeded)
+        {
+            LogUserCreatedWithPassword(logger);
+
+            string userId = await userManager.GetUserIdAsync(user);
+            string code = await userManager.GenerateEmailConfirmationTokenAsync(user);
+            code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+            string? callbackUrl = Url.Page(
+                "/Account/ConfirmEmail",
+                pageHandler: null,
+                values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
+                protocol: Request.Scheme);
+
+            if (callbackUrl is null)
+            {
+                ModelState.AddModelError(string.Empty, "Error: callback url unexpectedly null.");
+                return Page();
+            }
+            if (Input.Email is null)
+            {
+                ModelState.AddModelError(string.Empty, "Error: Email may not be null.");
+                return Page();
+            }
+            await emailSender.SendEmailAsync(Input.Email, "Confirm your email",
+                $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+
+            if (userManager.Options.SignIn.RequireConfirmedAccount)
+            {
+                return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
+            }
+            else
+            {
+                await signInManager.SignInAsync(user, isPersistent: false);
+                return LocalRedirect(returnUrl);
+            }
+        }
+        foreach (IdentityError error in result.Errors)
+        {
+            ModelState.AddModelError(string.Empty, error.Description);
         }
 
         // If we got this far, something failed, redisplay form

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml.cs
@@ -1,8 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 using System.Text.Encodings.Web;
 using EssentialCSharp.Web.Areas.Identity.Data;
-using EssentialCSharp.Web.Models;
 using EssentialCSharp.Web.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -15,7 +14,7 @@ using Microsoft.Extensions.Options;
 namespace EssentialCSharp.Web.Areas.Identity.Pages.Account;
 
 [AllowAnonymous]
-public class ResendEmailConfirmationModel(UserManager<EssentialCSharpWebUser> userManager, IEmailSender emailSender, ICaptchaService captchaService, IOptions<CaptchaOptions> optionsAccessor) : PageModel
+public class ResendEmailConfirmationModel(UserManager<EssentialCSharpWebUser> userManager, IEmailSender emailSender, ICaptchaValidationService captchaValidationService, IOptions<CaptchaOptions> optionsAccessor) : PageModel
 {
     private InputModel? _Input;
     [BindProperty]
@@ -37,8 +36,8 @@ public class ResendEmailConfirmationModel(UserManager<EssentialCSharpWebUser> us
     public async Task<IActionResult> OnPostAsync()
     {
         string? captchaToken = Request.Form[CaptchaOptions.HttpPostResponseKeyName];
-        HCaptchaResult? captchaResult = await captchaService.VerifyAsync(captchaToken, HttpContext.Connection.RemoteIpAddress?.ToString());
-        if (captchaResult?.Success != true)
+        CaptchaValidationResult captchaResult = await captchaValidationService.ValidateAsync(captchaToken, HttpContext.Connection.RemoteIpAddress?.ToString());
+        if (!captchaResult.ShouldProceed)
         {
             ModelState.AddModelError(string.Empty, "Human verification failed. Please try again.");
             return Page();

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -1,7 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 using EssentialCSharp.Web.Areas.Identity.Data;
-using EssentialCSharp.Web.Models;
 using EssentialCSharp.Web.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -11,7 +10,7 @@ using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Areas.Identity.Pages.Account;
 
-public class ResetPasswordModel(UserManager<EssentialCSharpWebUser> userManager, ICaptchaService captchaService, IOptions<CaptchaOptions> optionsAccessor) : PageModel
+public class ResetPasswordModel(UserManager<EssentialCSharpWebUser> userManager, ICaptchaValidationService captchaValidationService, IOptions<CaptchaOptions> optionsAccessor) : PageModel
 {
     private InputModel? _Input;
     [BindProperty]
@@ -63,8 +62,8 @@ public class ResetPasswordModel(UserManager<EssentialCSharpWebUser> userManager,
     public async Task<IActionResult> OnPostAsync()
     {
         string? captchaToken = Request.Form[CaptchaOptions.HttpPostResponseKeyName];
-        HCaptchaResult? captchaResult = await captchaService.VerifyAsync(captchaToken, HttpContext.Connection.RemoteIpAddress?.ToString());
-        if (captchaResult?.Success != true)
+        CaptchaValidationResult captchaResult = await captchaValidationService.ValidateAsync(captchaToken, HttpContext.Connection.RemoteIpAddress?.ToString());
+        if (!captchaResult.ShouldProceed)
         {
             ModelState.AddModelError(string.Empty, "Human verification failed. Please try again.");
             return Page();

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -46,6 +46,12 @@ public partial class ChatController : ControllerBase
         CaptchaValidationResult captchaValidation = await _CaptchaValidationService.ValidateAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken);
         if (!captchaValidation.ShouldProceed)
         {
+            if (captchaValidation.Outcome == CaptchaValidationOutcome.Disabled)
+            {
+                LogCaptchaConfigurationMissing(_Logger);
+                return StatusCode(503, new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" });
+            }
+
             if (captchaValidation.Outcome == CaptchaValidationOutcome.Unavailable)
             {
                 LogCaptchaServiceUnavailable(_Logger);
@@ -113,6 +119,14 @@ public partial class ChatController : ControllerBase
         CaptchaValidationResult captchaValidation = await _CaptchaValidationService.ValidateAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken);
         if (!captchaValidation.ShouldProceed)
         {
+            if (captchaValidation.Outcome == CaptchaValidationOutcome.Disabled)
+            {
+                LogCaptchaConfigurationMissing(_Logger);
+                Response.StatusCode = 503;
+                await Response.WriteAsJsonAsync(new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" }, cancellationToken);
+                return;
+            }
+
             if (captchaValidation.Outcome == CaptchaValidationOutcome.Unavailable)
             {
                 LogCaptchaServiceUnavailable(_Logger);
@@ -279,6 +293,9 @@ public partial class ChatController : ControllerBase
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "hCaptcha service unavailable during chat request — failing closed (503)")]
     private static partial void LogCaptchaServiceUnavailable(ILogger<ChatController> logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "hCaptcha configuration missing during chat request — failing closed (503)")]
+    private static partial void LogCaptchaConfigurationMissing(ILogger<ChatController> logger);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "hCaptcha validation failed for chat request — error codes: {ErrorCodes}")]
     private static partial void LogCaptchaValidationFailed(ILogger<ChatController> logger, string errorCodes);

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -7,7 +7,6 @@ using EssentialCSharp.Web.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Controllers;
 
@@ -20,47 +19,17 @@ public partial class ChatController : ControllerBase
 {
     private readonly AIChatService _AIChatService;
     private readonly ResponseIdValidationService _ResponseIdValidationService;
-    private readonly ICaptchaService _CaptchaService;
-    private readonly CaptchaOptions _CaptchaOptions;
+    private readonly ICaptchaValidationService _CaptchaValidationService;
     private readonly ILogger<ChatController> _Logger;
 
     public ChatController(ILogger<ChatController> logger, AIChatService aiChatService,
         ResponseIdValidationService responseIdValidationService,
-        ICaptchaService captchaService, IOptions<CaptchaOptions> captchaOptions)
+        ICaptchaValidationService captchaValidationService)
     {
         _AIChatService = aiChatService;
         _ResponseIdValidationService = responseIdValidationService;
-        _CaptchaService = captchaService;
-        _CaptchaOptions = captchaOptions.Value;
+        _CaptchaValidationService = captchaValidationService;
         _Logger = logger;
-    }
-
-    /// <summary>
-    /// Validates the hCaptcha token when captcha is configured.
-    /// Returns <c>true</c> when captcha is not configured (dev mode) or when the token is valid.
-    /// Returns <c>false</c> for missing or invalid tokens.
-    /// Returns <c>null</c> when hCaptcha cannot be reached, so the caller can fail closed.
-    /// </summary>
-    private async Task<bool?> IsCaptchaValidAsync(string? token, string? remoteIp, CancellationToken ct)
-    {
-        if (string.IsNullOrWhiteSpace(_CaptchaOptions.SecretKey))
-            return true; // captcha not configured — skip validation
-
-        if (string.IsNullOrWhiteSpace(token))
-            return false; // token required when captcha is configured — reject without an outbound call
-
-        HCaptchaResult? result = await _CaptchaService.VerifyAsync(token, remoteIp, ct);
-        if (result is null)
-        {
-            LogCaptchaServiceUnavailable(_Logger); // hCaptcha unreachable — fail closed
-            return null;
-        }
-
-        if (!result.Success)
-        {
-            LogCaptchaValidationFailed(_Logger, string.Join(',', result.ErrorCodes ?? []));
-        }
-        return result.Success;
     }
 
     [HttpPost("message")]
@@ -74,11 +43,22 @@ public partial class ChatController : ControllerBase
         if (string.IsNullOrEmpty(userId))
             return Unauthorized();
 
-        bool? captchaValid = await IsCaptchaValidAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken);
-        if (captchaValid is null)
-            return StatusCode(503, new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" });
-        if (!captchaValid.Value)
+        CaptchaValidationResult captchaValidation = await _CaptchaValidationService.ValidateAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken);
+        if (!captchaValidation.ShouldProceed)
+        {
+            if (captchaValidation.Outcome == CaptchaValidationOutcome.Unavailable)
+            {
+                LogCaptchaServiceUnavailable(_Logger);
+                return StatusCode(503, new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" });
+            }
+
+            if (captchaValidation.Outcome == CaptchaValidationOutcome.Invalid)
+            {
+                LogCaptchaValidationFailed(_Logger, string.Join(',', captchaValidation.Response?.ErrorCodes ?? []));
+            }
+
             return StatusCode(403, new { error = "Human verification required.", errorCode = "captcha_failed" });
+        }
 
         var previousResponseId = string.IsNullOrWhiteSpace(request.PreviousResponseId)
             ? null
@@ -130,15 +110,22 @@ public partial class ChatController : ControllerBase
             return;
         }
 
-        bool? captchaValid = await IsCaptchaValidAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken);
-        if (captchaValid is null)
+        CaptchaValidationResult captchaValidation = await _CaptchaValidationService.ValidateAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken);
+        if (!captchaValidation.ShouldProceed)
         {
-            Response.StatusCode = 503;
-            await Response.WriteAsJsonAsync(new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" }, cancellationToken);
-            return;
-        }
-        if (!captchaValid.Value)
-        {
+            if (captchaValidation.Outcome == CaptchaValidationOutcome.Unavailable)
+            {
+                LogCaptchaServiceUnavailable(_Logger);
+                Response.StatusCode = 503;
+                await Response.WriteAsJsonAsync(new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" }, cancellationToken);
+                return;
+            }
+
+            if (captchaValidation.Outcome == CaptchaValidationOutcome.Invalid)
+            {
+                LogCaptchaValidationFailed(_Logger, string.Join(',', captchaValidation.Response?.ErrorCodes ?? []));
+            }
+
             Response.StatusCode = 403;
             await Response.WriteAsJsonAsync(new { error = "Human verification required.", errorCode = "captcha_failed" }, cancellationToken);
             return;

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -46,24 +46,7 @@ public partial class ChatController : ControllerBase
         CaptchaValidationResult captchaValidation = await _CaptchaValidationService.ValidateAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken);
         if (!captchaValidation.ShouldProceed)
         {
-            if (captchaValidation.Outcome == CaptchaValidationOutcome.Disabled)
-            {
-                LogCaptchaConfigurationMissing(_Logger);
-                return StatusCode(503, new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" });
-            }
-
-            if (captchaValidation.Outcome == CaptchaValidationOutcome.Unavailable)
-            {
-                LogCaptchaServiceUnavailable(_Logger);
-                return StatusCode(503, new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" });
-            }
-
-            if (captchaValidation.Outcome == CaptchaValidationOutcome.Invalid)
-            {
-                LogCaptchaValidationFailed(_Logger, string.Join(',', captchaValidation.Response?.ErrorCodes ?? []));
-            }
-
-            return StatusCode(403, new { error = "Human verification required.", errorCode = "captcha_failed" });
+            return HandleCaptchaValidationFailure(captchaValidation);
         }
 
         var previousResponseId = string.IsNullOrWhiteSpace(request.PreviousResponseId)
@@ -129,29 +112,7 @@ public partial class ChatController : ControllerBase
         CaptchaValidationResult captchaValidation = await _CaptchaValidationService.ValidateAsync(request.CaptchaResponse, HttpContext.Connection.RemoteIpAddress?.ToString(), cancellationToken);
         if (!captchaValidation.ShouldProceed)
         {
-            if (captchaValidation.Outcome == CaptchaValidationOutcome.Disabled)
-            {
-                LogCaptchaConfigurationMissing(_Logger);
-                Response.StatusCode = 503;
-                await Response.WriteAsJsonAsync(new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" }, cancellationToken);
-                return;
-            }
-
-            if (captchaValidation.Outcome == CaptchaValidationOutcome.Unavailable)
-            {
-                LogCaptchaServiceUnavailable(_Logger);
-                Response.StatusCode = 503;
-                await Response.WriteAsJsonAsync(new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" }, cancellationToken);
-                return;
-            }
-
-            if (captchaValidation.Outcome == CaptchaValidationOutcome.Invalid)
-            {
-                LogCaptchaValidationFailed(_Logger, string.Join(',', captchaValidation.Response?.ErrorCodes ?? []));
-            }
-
-            Response.StatusCode = 403;
-            await Response.WriteAsJsonAsync(new { error = "Human verification required.", errorCode = "captcha_failed" }, cancellationToken);
+            await HandleCaptchaValidationFailureAsync(captchaValidation, cancellationToken);
             return;
         }
 
@@ -334,6 +295,61 @@ public partial class ChatController : ControllerBase
                 // ObjectDisposedException on abrupt client disconnect — swallow expected
                 // transport/disconnect exceptions to avoid masking the original exception.
             }
+        }
+    }
+
+    private IActionResult HandleCaptchaValidationFailure(CaptchaValidationResult captchaValidation)
+    {
+        return captchaValidation.Outcome switch
+        {
+            CaptchaValidationOutcome.Disabled => LogAndReturn503(),
+            CaptchaValidationOutcome.Unavailable => LogAndReturn503(),
+            CaptchaValidationOutcome.Invalid => LogInvalidAndReturn403(),
+            _ => StatusCode(403, new { error = "Human verification required.", errorCode = "captcha_failed" })
+        };
+
+        IActionResult LogAndReturn503()
+        {
+            if (captchaValidation.Outcome == CaptchaValidationOutcome.Disabled)
+                LogCaptchaConfigurationMissing(_Logger);
+            else
+                LogCaptchaServiceUnavailable(_Logger);
+
+            return StatusCode(503, new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" });
+        }
+
+        IActionResult LogInvalidAndReturn403()
+        {
+            LogCaptchaValidationFailed(_Logger, string.Join(',', captchaValidation.Response?.ErrorCodes ?? []));
+            return StatusCode(403, new { error = "Human verification required.", errorCode = "captcha_failed" });
+        }
+    }
+
+    private async Task HandleCaptchaValidationFailureAsync(CaptchaValidationResult captchaValidation, CancellationToken cancellationToken)
+    {
+        switch (captchaValidation.Outcome)
+        {
+            case CaptchaValidationOutcome.Disabled:
+            case CaptchaValidationOutcome.Unavailable:
+                if (captchaValidation.Outcome == CaptchaValidationOutcome.Disabled)
+                    LogCaptchaConfigurationMissing(_Logger);
+                else
+                    LogCaptchaServiceUnavailable(_Logger);
+
+                Response.StatusCode = 503;
+                await Response.WriteAsJsonAsync(new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" }, cancellationToken);
+                break;
+
+            case CaptchaValidationOutcome.Invalid:
+                LogCaptchaValidationFailed(_Logger, string.Join(',', captchaValidation.Response?.ErrorCodes ?? []));
+                Response.StatusCode = 403;
+                await Response.WriteAsJsonAsync(new { error = "Human verification required.", errorCode = "captcha_failed" }, cancellationToken);
+                break;
+
+            default:
+                Response.StatusCode = 403;
+                await Response.WriteAsJsonAsync(new { error = "Human verification required.", errorCode = "captcha_failed" }, cancellationToken);
+                break;
         }
     }
 

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -344,8 +344,11 @@ public partial class ChatController : ControllerBase
         }
     }
 
-    private static object CaptchaUnavailableResponseBody =>
-        new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" };
+    private static readonly object CaptchaUnavailableResponseBody = new
+    {
+        error = "Human verification is temporarily unavailable. Please try again later.",
+        errorCode = "captcha_unavailable"
+    };
 
     private void LogCaptchaUnavailable(CaptchaValidationOutcome outcome)
     {

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -302,20 +302,15 @@ public partial class ChatController : ControllerBase
     {
         return captchaValidation.Outcome switch
         {
-            CaptchaValidationOutcome.Disabled => LogAndReturn503(),
-            CaptchaValidationOutcome.Unavailable => LogAndReturn503(),
+            CaptchaValidationOutcome.Disabled or CaptchaValidationOutcome.Unavailable => LogAndReturn503(),
             CaptchaValidationOutcome.Invalid => LogInvalidAndReturn403(),
             _ => StatusCode(403, new { error = "Human verification required.", errorCode = "captcha_failed" })
         };
 
         IActionResult LogAndReturn503()
         {
-            if (captchaValidation.Outcome == CaptchaValidationOutcome.Disabled)
-                LogCaptchaConfigurationMissing(_Logger);
-            else
-                LogCaptchaServiceUnavailable(_Logger);
-
-            return StatusCode(503, new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" });
+            LogCaptchaUnavailable(captchaValidation.Outcome);
+            return StatusCode(503, CaptchaUnavailableResponseBody);
         }
 
         IActionResult LogInvalidAndReturn403()
@@ -331,13 +326,9 @@ public partial class ChatController : ControllerBase
         {
             case CaptchaValidationOutcome.Disabled:
             case CaptchaValidationOutcome.Unavailable:
-                if (captchaValidation.Outcome == CaptchaValidationOutcome.Disabled)
-                    LogCaptchaConfigurationMissing(_Logger);
-                else
-                    LogCaptchaServiceUnavailable(_Logger);
-
+                LogCaptchaUnavailable(captchaValidation.Outcome);
                 Response.StatusCode = 503;
-                await Response.WriteAsJsonAsync(new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" }, cancellationToken);
+                await Response.WriteAsJsonAsync(CaptchaUnavailableResponseBody, cancellationToken);
                 break;
 
             case CaptchaValidationOutcome.Invalid:
@@ -351,6 +342,17 @@ public partial class ChatController : ControllerBase
                 await Response.WriteAsJsonAsync(new { error = "Human verification required.", errorCode = "captcha_failed" }, cancellationToken);
                 break;
         }
+    }
+
+    private static object CaptchaUnavailableResponseBody =>
+        new { error = "Human verification is temporarily unavailable. Please try again later.", errorCode = "captcha_unavailable" };
+
+    private void LogCaptchaUnavailable(CaptchaValidationOutcome outcome)
+    {
+        if (outcome == CaptchaValidationOutcome.Disabled)
+            LogCaptchaConfigurationMissing(_Logger);
+        else
+            LogCaptchaServiceUnavailable(_Logger);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "hCaptcha service unavailable during chat request — failing closed (503)")]

--- a/EssentialCSharp.Web/Extensions/IServiceCollectionExtensions.cs
+++ b/EssentialCSharp.Web/Extensions/IServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ public static class IServiceCollectionExtensions
     {
         services.Configure<CaptchaOptions>(CaptchaOptions);
         services.AddSingleton<ICaptchaService, CaptchaService>();
+        services.AddSingleton<ICaptchaValidationService, CaptchaValidationService>();
         services.AddHttpClient("hCaptcha", c =>
         {
             c.BaseAddress = new Uri("https://api.hcaptcha.com");

--- a/EssentialCSharp.Web/Services/CaptchaService.cs
+++ b/EssentialCSharp.Web/Services/CaptchaService.cs
@@ -74,6 +74,10 @@ public partial class CaptchaService(IHttpClientFactory clientFactory, IOptions<C
             res.EnsureSuccessStatusCode();
             return JsonSerializer.Deserialize<HCaptchaResult>(await res.Content.ReadAsStringAsync(cancellationToken));
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
         {
             LogSiteverifyFailed(logger, ex);

--- a/EssentialCSharp.Web/Services/CaptchaValidationOutcome.cs
+++ b/EssentialCSharp.Web/Services/CaptchaValidationOutcome.cs
@@ -1,0 +1,10 @@
+namespace EssentialCSharp.Web.Services;
+
+public enum CaptchaValidationOutcome
+{
+    Disabled,
+    MissingToken,
+    Unavailable,
+    Invalid,
+    Valid
+}

--- a/EssentialCSharp.Web/Services/CaptchaValidationResult.cs
+++ b/EssentialCSharp.Web/Services/CaptchaValidationResult.cs
@@ -1,0 +1,8 @@
+using EssentialCSharp.Web.Models;
+
+namespace EssentialCSharp.Web.Services;
+
+public sealed record CaptchaValidationResult(CaptchaValidationOutcome Outcome, HCaptchaResult? Response)
+{
+    public bool ShouldProceed => Outcome is CaptchaValidationOutcome.Disabled or CaptchaValidationOutcome.Valid;
+}

--- a/EssentialCSharp.Web/Services/CaptchaValidationResult.cs
+++ b/EssentialCSharp.Web/Services/CaptchaValidationResult.cs
@@ -4,5 +4,5 @@ namespace EssentialCSharp.Web.Services;
 
 public sealed record CaptchaValidationResult(CaptchaValidationOutcome Outcome, HCaptchaResult? Response)
 {
-    public bool ShouldProceed => Outcome is CaptchaValidationOutcome.Disabled or CaptchaValidationOutcome.Valid;
+    public bool ShouldProceed => Outcome is CaptchaValidationOutcome.Valid;
 }

--- a/EssentialCSharp.Web/Services/CaptchaValidationService.cs
+++ b/EssentialCSharp.Web/Services/CaptchaValidationService.cs
@@ -1,0 +1,29 @@
+using EssentialCSharp.Web.Models;
+using Microsoft.Extensions.Options;
+
+namespace EssentialCSharp.Web.Services;
+
+public sealed class CaptchaValidationService(ICaptchaService captchaService, IOptions<CaptchaOptions> optionsAccessor) : ICaptchaValidationService
+{
+    private CaptchaOptions Options { get; } = optionsAccessor.Value;
+
+    public Task<CaptchaValidationResult> ValidateAsync(string? response, CancellationToken cancellationToken = default)
+        => ValidateAsync(response, remoteIp: null, cancellationToken);
+
+    public async Task<CaptchaValidationResult> ValidateAsync(string? response, string? remoteIp, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(Options.SecretKey) || string.IsNullOrWhiteSpace(Options.SiteKey))
+            return new CaptchaValidationResult(CaptchaValidationOutcome.Disabled, null);
+
+        if (string.IsNullOrWhiteSpace(response))
+            return new CaptchaValidationResult(CaptchaValidationOutcome.MissingToken, null);
+
+        HCaptchaResult? result = await captchaService.VerifyAsync(response, remoteIp, cancellationToken);
+        if (result is null)
+            return new CaptchaValidationResult(CaptchaValidationOutcome.Unavailable, null);
+
+        return new CaptchaValidationResult(
+            result.Success ? CaptchaValidationOutcome.Valid : CaptchaValidationOutcome.Invalid,
+            result);
+    }
+}

--- a/EssentialCSharp.Web/Services/CaptchaValidationService.cs
+++ b/EssentialCSharp.Web/Services/CaptchaValidationService.cs
@@ -10,6 +10,16 @@ public sealed class CaptchaValidationService(ICaptchaService captchaService, IOp
     public Task<CaptchaValidationResult> ValidateAsync(string? response, CancellationToken cancellationToken = default)
         => ValidateAsync(response, remoteIp: null, cancellationToken);
 
+    /// <summary>
+    /// Validates a captcha response.
+    /// </summary>
+    /// <remarks>
+    /// IMPORTANT: Both <see cref="CaptchaOptions.SecretKey"/> and <see cref="CaptchaOptions.SiteKey"/> must be configured
+    /// (non-empty) for captcha validation to be enabled. If either key is missing, the validation is marked as
+    /// <see cref="CaptchaValidationOutcome.Disabled"/> and the captcha service is not invoked. This is intentional:
+    /// HCaptcha requires both keys to function properly, and partial configuration (one key set, one missing)
+    /// indicates a deployment configuration error that should be detected early.
+    /// </remarks>
     public async Task<CaptchaValidationResult> ValidateAsync(string? response, string? remoteIp, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(Options.SecretKey) || string.IsNullOrWhiteSpace(Options.SiteKey))

--- a/EssentialCSharp.Web/Services/CaptchaValidationService.cs
+++ b/EssentialCSharp.Web/Services/CaptchaValidationService.cs
@@ -6,6 +6,9 @@ namespace EssentialCSharp.Web.Services;
 public sealed class CaptchaValidationService(ICaptchaService captchaService, IOptions<CaptchaOptions> optionsAccessor) : ICaptchaValidationService
 {
     private CaptchaOptions Options { get; } = optionsAccessor.Value;
+    private bool IsCaptchaConfigurationComplete =>
+        !string.IsNullOrWhiteSpace(Options.SecretKey) &&
+        !string.IsNullOrWhiteSpace(Options.SiteKey);
 
     public Task<CaptchaValidationResult> ValidateAsync(string? response, CancellationToken cancellationToken = default)
         => ValidateAsync(response, remoteIp: null, cancellationToken);
@@ -22,7 +25,7 @@ public sealed class CaptchaValidationService(ICaptchaService captchaService, IOp
     /// </remarks>
     public async Task<CaptchaValidationResult> ValidateAsync(string? response, string? remoteIp, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(Options.SecretKey) || string.IsNullOrWhiteSpace(Options.SiteKey))
+        if (!IsCaptchaConfigurationComplete)
             return new CaptchaValidationResult(CaptchaValidationOutcome.Disabled, null);
 
         if (string.IsNullOrWhiteSpace(response))

--- a/EssentialCSharp.Web/Services/ICaptchaValidationService.cs
+++ b/EssentialCSharp.Web/Services/ICaptchaValidationService.cs
@@ -1,0 +1,7 @@
+namespace EssentialCSharp.Web.Services;
+
+public interface ICaptchaValidationService
+{
+    Task<CaptchaValidationResult> ValidateAsync(string? response, CancellationToken cancellationToken = default);
+    Task<CaptchaValidationResult> ValidateAsync(string? response, string? remoteIp, CancellationToken cancellationToken = default);
+}

--- a/test_output.txt
+++ b/test_output.txt
@@ -1,0 +1,1 @@
+Running tests from D:\copilot-worktrees\EssentialCSharp.Web\benjaminmichaelis-super-giggle\EssentialCSharp.Web.Tests\bin\Release\net10.0\EssentialCSharp.Web.Tests.dll (net10.0|x64)


### PR DESCRIPTION
This change removes the per-page captcha handling drift and centralizes the policy in one shared validation service.

## What changed
- Added `ICaptchaValidationService` with explicit outcomes for missing token, unavailable, invalid, and valid captcha states.
- Switched chat and the identity pages to the shared policy layer.
- Kept register's detailed hCaptcha error-code mapping intact while preserving the simpler generic messages elsewhere.
- Added tests for the shared validation behavior.
- Missing captcha configuration now fails closed instead of allowing requests through.

## Notes
- `ICaptchaService` still owns raw hCaptcha verification.
- Chat keeps its existing 403 vs 503 behavior for invalid vs unavailable captcha.
