### PR TITLE
Use host-managed logger for startup profiler logging

### DIFF
--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -140,13 +140,6 @@ public partial class Program
         ConfigurationManager configuration = builder.Configuration;
         string connectionString = builder.Configuration.GetConnectionString("EssentialCSharpWebContextConnection") ?? throw new InvalidOperationException("Connection string 'EssentialCSharpWebContextConnection' not found.");
 
-        // Create a logger that's accessible throughout the entire method
-        var loggerFactory = LoggerFactory.Create(loggingBuilder =>
-            loggingBuilder.AddConsole().SetMinimumLevel(LogLevel.Information));
-        var initialLogger = loggerFactory.CreateLogger<Program>();
-        if (profilerSkippedUnsupportedPlatform)
-            LogSkippingUnsupportedAzureMonitorProfiler(initialLogger, RuntimeInformation.OSDescription);
-
         builder.Services.AddDbContext<EssentialCSharpWebContext>(options => options.UseSqlServer(connectionString, sql => sql.EnableRetryOnFailure(5)));
 
         // Must be registered before AddDataProtection(): hosted services start in registration
@@ -441,9 +434,12 @@ public partial class Program
              });
         }
 
-        loggerFactory.Dispose();
-
         WebApplication app = builder.Build();
+
+        if (profilerSkippedUnsupportedPlatform)
+            LogSkippingUnsupportedAzureMonitorProfiler(
+                app.Services.GetRequiredService<ILogger<Program>>(),
+                RuntimeInformation.OSDescription);
 
         // Configure the HTTP request pipeline.
         if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
## Why
Startup used a manually created `LoggerFactory` to emit an early log entry. That creates a separate logging pipeline from the host and is less consistent with ASP.NET Core startup logging patterns.

## What changed
- Removed ad-hoc `LoggerFactory.Create(...)` and its explicit disposal from `Program.cs`.
- Kept the existing structured log message (`LogSkippingUnsupportedAzureMonitorProfiler`) but moved its call to after `builder.Build()`.
- Logged via `app.Services.GetRequiredService<ILogger<Program>>()` so startup logging stays on the host-managed providers and configuration.

## Notes for reviewers
This intentionally shifts that single pre-build log call to post-build, trading a tiny timing change for a single, consistent logging pipeline.

## Validation
- `dotnet build .\EssentialCSharp.Web.slnx -c Release --no-restore`
- `dotnet test .\EssentialCSharp.Chat.Tests\EssentialCSharp.Chat.Tests.csproj -c Release --no-build --no-restore -- --no-ansi --no-progress`
- `EssentialCSharp.Web.Tests` did not exit cleanly in this environment (test session cancellation/timeout behavior).