### PR TITLE
feat: Cancel pending deployments on successful production deployment

### DIFF
--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -232,61 +232,61 @@ jobs:
           # --retry-all-errors ensures HTTP 5xx (cold-start 503s) also trigger retries
           curl --fail --retry 10 --retry-delay 15 --retry-all-errors --max-time 30 "https://$FQDN/health"
 
-       - name: Cancel pending deployment workflow runs
-         uses: actions/github-script@v9
-         with:
-           script: |
-             // Cancel pending workflow runs queued from earlier commits.
-             // Uses context.workflow instead of hardcoded filename for resilience.
-             let totalCancelledCount = 0;
-             let page = 1;
-             
-             try {
-               while (true) {
-                 const { data: runs } = await github.rest.actions.listWorkflowRuns({
-                   owner: context.repo.owner,
-                   repo: context.repo.repo,
-                   workflow_id: context.workflow,
-                   status: 'queued',
-                   per_page: 100,
-                   page: page
-                 });
-                 
-                 if (runs.length === 0) {
-                   break;
-                 }
-                 
-                 for (const run of runs) {
-                   if (run.id === context.runId) {
-                     core.debug(`Skipping current run #${run.id}`);
-                     continue;
-                   }
-                   
-                   try {
-                     core.info(`Cancelling queued run #${run.id} (commit: ${run.head_sha.substring(0, 7)}, branch: ${run.head_branch}, created: ${run.created_at})`);
-                     await github.rest.actions.cancelWorkflowRun({
-                       owner: context.repo.owner,
-                       repo: context.repo.repo,
-                       run_id: run.id
-                     });
-                     totalCancelledCount++;
-                   } catch (error) {
-                     core.warning(`Failed to cancel run #${run.id}: ${error.message}`);
-                   }
-                 }
-                 
-                 // Last page has fewer results than requested (pagination)
-                 if (runs.length < 100) {
-                   break;
-                 }
-                 page++;
-               }
-             } catch (error) {
-               core.warning(`Failed to list workflow runs: ${error.message}`);
-               core.info('Continuing with deployment despite cancellation script error');
-             }
-             
-             core.info(`Cancelled ${totalCancelledCount} pending workflow run(s)`);
+      - name: Cancel pending deployment workflow runs
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Cancel pending workflow runs queued from earlier commits.
+            // Uses context.workflow instead of hardcoded filename for resilience.
+            let totalCancelledCount = 0;
+            let page = 1;
+            
+            try {
+              while (true) {
+                const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: context.workflow,
+                  status: 'queued',
+                  per_page: 100,
+                  page: page
+                });
+                
+                if (runs.length === 0) {
+                  break;
+                }
+                
+                for (const run of runs) {
+                  if (run.id === context.runId) {
+                    core.debug(`Skipping current run #${run.id}`);
+                    continue;
+                  }
+                  
+                  try {
+                    core.info(`Cancelling queued run #${run.id} (commit: ${run.head_sha.substring(0, 7)}, branch: ${run.head_branch}, created: ${run.created_at})`);
+                    await github.rest.actions.cancelWorkflowRun({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      run_id: run.id
+                    });
+                    totalCancelledCount++;
+                  } catch (error) {
+                    core.warning(`Failed to cancel run #${run.id}: ${error.message}`);
+                  }
+                }
+                
+                // Last page has fewer results than requested (pagination)
+                if (runs.length < 100) {
+                  break;
+                }
+                page++;
+              }
+            } catch (error) {
+              core.warning(`Failed to list workflow runs: ${error.message}`);
+              core.info('Continuing with deployment despite cancellation script error');
+            }
+            
+            core.info(`Cancelled ${totalCancelledCount} pending workflow run(s)`);
 
       - name: Tag commit as deployed
         run: |
@@ -304,3 +304,4 @@ jobs:
             az logout
             az cache purge
             az account clear
+

--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -236,29 +236,34 @@ jobs:
          uses: actions/github-script@v9
          with:
            script: |
+             // Cancel pending workflow runs queued from earlier commits.
+             // Uses context.workflow instead of hardcoded filename for resilience.
              let totalCancelledCount = 0;
              let page = 1;
-             let hasMore = true;
              
-             while (hasMore) {
-               const { data: runs } = await github.rest.actions.listWorkflowRuns({
-                 owner: context.repo.owner,
-                 repo: context.repo.repo,
-                 workflow_id: 'Build-Test-And-Deploy.yml',
-                 status: 'queued',
-                 per_page: 100,
-                 page: page
-               });
-               
-               if (runs.length === 0) {
-                 hasMore = false;
-                 break;
-               }
-               
-               for (const run of runs) {
-                 if (run.id !== context.runId) {
+             try {
+               while (true) {
+                 const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                   owner: context.repo.owner,
+                   repo: context.repo.repo,
+                   workflow_id: context.workflow,
+                   status: 'queued',
+                   per_page: 100,
+                   page: page
+                 });
+                 
+                 if (runs.length === 0) {
+                   break;
+                 }
+                 
+                 for (const run of runs) {
+                   if (run.id === context.runId) {
+                     core.debug(`Skipping current run #${run.id}`);
+                     continue;
+                   }
+                   
                    try {
-                     core.info(`Cancelling queued run #${run.id} (commit: ${run.head_sha.substring(0, 7)}, branch: ${run.head_branch})`);
+                     core.info(`Cancelling queued run #${run.id} (commit: ${run.head_sha.substring(0, 7)}, branch: ${run.head_branch}, created: ${run.created_at})`);
                      await github.rest.actions.cancelWorkflowRun({
                        owner: context.repo.owner,
                        repo: context.repo.repo,
@@ -269,10 +274,18 @@ jobs:
                      core.warning(`Failed to cancel run #${run.id}: ${error.message}`);
                    }
                  }
+                 
+                 // Last page has fewer results than requested (pagination)
+                 if (runs.length < 100) {
+                   break;
+                 }
+                 page++;
                }
-               
-               page++;
+             } catch (error) {
+               core.warning(`Failed to list workflow runs: ${error.message}`);
+               core.info('Continuing with deployment despite cancellation script error');
              }
+             
              core.info(`Cancelled ${totalCancelledCount} pending workflow run(s)`);
 
       - name: Tag commit as deployed

--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: write
 
 jobs:
   build-and-test:
@@ -155,6 +156,7 @@ jobs:
     permissions:
       id-token: write
       contents: write  # needed for git deploy tag
+      actions: write
 
     steps:
       - uses: actions/checkout@v6
@@ -229,6 +231,49 @@ jobs:
             --query "properties.configuration.ingress.fqdn" -o tsv)
           # --retry-all-errors ensures HTTP 5xx (cold-start 503s) also trigger retries
           curl --fail --retry 10 --retry-delay 15 --retry-all-errors --max-time 30 "https://$FQDN/health"
+
+       - name: Cancel pending deployment workflow runs
+         uses: actions/github-script@v9
+         with:
+           script: |
+             let totalCancelledCount = 0;
+             let page = 1;
+             let hasMore = true;
+             
+             while (hasMore) {
+               const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 workflow_id: 'Build-Test-And-Deploy.yml',
+                 status: 'queued',
+                 per_page: 100,
+                 page: page
+               });
+               
+               if (runs.length === 0) {
+                 hasMore = false;
+                 break;
+               }
+               
+               for (const run of runs) {
+                 if (run.id !== context.runId) {
+                   try {
+                     core.info(`Cancelling queued run #${run.id} (commit: ${run.head_sha.substring(0, 7)}, branch: ${run.head_branch})`);
+                     await github.rest.actions.cancelWorkflowRun({
+                       owner: context.repo.owner,
+                       repo: context.repo.repo,
+                       run_id: run.id
+                     });
+                     totalCancelledCount++;
+                   } catch (error) {
+                     core.warning(`Failed to cancel run #${run.id}: ${error.message}`);
+                   }
+                 }
+               }
+               
+               page++;
+             }
+             core.info(`Cancelled ${totalCancelledCount} pending workflow run(s)`);
 
       - name: Tag commit as deployed
         run: |

--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  actions: write
 
 jobs:
   build-and-test:
@@ -243,7 +242,7 @@ jobs:
             
             try {
               while (true) {
-                const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                const { data } = await github.rest.actions.listWorkflowRuns({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   workflow_id: context.workflow,
@@ -251,6 +250,7 @@ jobs:
                   per_page: 100,
                   page: page
                 });
+                const runs = data.workflow_runs;
                 
                 if (runs.length === 0) {
                   break;


### PR DESCRIPTION
## Description

Implements automatic cancellation of pending GitHub Actions workflow runs when a production deployment succeeds. This resolves the issue where multiple concurrent deployments could pile up and waste CI/CD resources.

## Why This Matters

When developers push code frequently, GitHub Actions queues up multiple workflow runs. Previously, if older code deployed to production while newer code was still building, both would complete—wasting resources and potentially causing confusion about which version is deployed.

With this change, once a production deployment succeeds (confirmed by the smoke test), any pending workflow runs are automatically cancelled, ensuring only necessary CI/CD work runs.

## How It Works

1. Developer pushes commits → GitHub Actions triggers workflow
2. Build, test, and dev deployment stages complete
3. Production deployment begins
4. Smoke test validates the deployment is healthy
5. **[NEW]** Cancel pending workflow runs step:
   - Lists all queued runs of the same workflow
   - Skips the current run (prevents self-cancellation)
   - Cancels each queued run with proper error handling
   - Reports cancellation count in logs
6. Git tag marks successful production deployment

## Key Features

- ✅ Only cancels after successful deployment validation (post-smoke test)
- ✅ Safe pagination for handling 100+ queued runs
- ✅ Multiple levels of error handling (transient API failures don't block deployment)
- ✅ Comprehensive logging with commit info for debugging
- ✅ Uses GitHub context variables (resilient to config changes)
- ✅ Excludes current run from cancellation

## Code Review History

This implementation was reviewed by independent agents (GPT 5.5 and Opus 4.6) and addresses all critical findings:

- ✅ Replaced hardcoded workflow filename with `context.workflow` (resilient to renames)
- ✅ Added outer try-catch around API calls (deployment succeeds even if cancellation fails)
- ✅ Fixed pagination logic for correctness
- ✅ Added comprehensive logging for observability
- ✅ Validated YAML syntax

## Testing Recommendations

- Push two commits rapidly; verify the first run gets cancelled when the second deploys
- Monitor logs for proper commit info in cancellation messages
- Verify deployment completion is not blocked by API failures

Closes #149