### PR TITLE
Use latest production deploy run in concurrency gate

### DIFF
--- a/.github/workflows/Build-Test-And-Deploy.yml
+++ b/.github/workflows/Build-Test-And-Deploy.yml
@@ -149,7 +149,7 @@ jobs:
     needs: [deploy-development]
     concurrency:
       group: deploy-production
-      cancel-in-progress: false
+      cancel-in-progress: true
     environment:
       name: "Production"
     permissions:


### PR DESCRIPTION
Production deployments could be blocked waiting on older runs in the same concurrency group. This updates the production gate to prioritize the latest run so stale deployments do not hold the queue.

## What changed
- Updated `.github/workflows/Build-Test-And-Deploy.yml` in `deploy-production` concurrency:
  - `cancel-in-progress: false` -> `cancel-in-progress: true`
- Kept the existing concurrency group (`deploy-production`) and all other deploy behavior unchanged.

## Notes
- This aligns production deploy behavior with the goal of always deploying the newest commit when multiple runs overlap.