### PR TITLE
Extract hard-coded routes into centralized constants (resolves #747)

### DIFF
--- a/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
+++ b/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
@@ -246,6 +246,72 @@ public class SitemapXmlHelpersTests : IntegrationTestBase
         await Assert.That(siteMappingNode.LastModificationDate).IsNull();
     }
 
+    [Test]
+    public async Task GenerateSitemapXml_GuidelinesRoute_HasHighPriority()
+    {
+        // Arrange
+        var siteMappings = new List<SiteMapping>();
+        var baseUrl = "https://test.example.com/";
+
+        // Act
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappings,
+            routeConfigurationService,
+            baseUrl,
+            out var nodes);
+
+        // Assert — /guidelines should have priority 0.9 (higher than default 0.5)
+        var guidelinesNode = nodes.FirstOrDefault(n => n.Url.Contains("/guidelines", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(guidelinesNode).IsNotNull();
+        await Assert.That(guidelinesNode!.Priority).IsEqualTo(0.9M);
+        await Assert.That(guidelinesNode.ChangeFrequency).IsEqualTo(ChangeFrequency.Monthly);
+    }
+
+    [Test]
+    public async Task GenerateSitemapXml_TermsOfServiceRoute_HasYearlyFrequencyAndLowPriority()
+    {
+        // Arrange
+        var siteMappings = new List<SiteMapping>();
+        var baseUrl = "https://test.example.com/";
+
+        // Act
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappings,
+            routeConfigurationService,
+            baseUrl,
+            out var nodes);
+
+        // Assert — /termsofservice changes rarely (Yearly) and has low priority (0.2)
+        var tosNode = nodes.FirstOrDefault(n => n.Url.Contains("/termsofservice", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(tosNode).IsNotNull();
+        await Assert.That(tosNode!.Priority).IsEqualTo(0.2M);
+        await Assert.That(tosNode.ChangeFrequency).IsEqualTo(ChangeFrequency.Yearly);
+    }
+
+    [Test]
+    public async Task GenerateSitemapXml_UnknownRoute_UsesDefaultSeoValues()
+    {
+        // Arrange
+        var siteMappings = new List<SiteMapping> { CreateSiteMapping(1, 1, true, "test-page-unknown-route") };
+        var baseUrl = "https://test.example.com/";
+
+        // Act
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappings,
+            routeConfigurationService,
+            baseUrl,
+            out var nodes);
+
+        // Assert — content pages without specific config get default SEO values
+        var contentNode = nodes.FirstOrDefault(n => n.Url.Contains("test-page-unknown-route", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(contentNode).IsNotNull();
+        await Assert.That(contentNode!.Priority).IsEqualTo(0.5M);
+        await Assert.That(contentNode.ChangeFrequency).IsEqualTo(ChangeFrequency.Monthly);
+    }
+
     private static SiteMapping CreateSiteMapping(
         int chapterNumber,
         int pageNumber,

--- a/EssentialCSharp.Web/Constants/RouteConstants.cs
+++ b/EssentialCSharp.Web/Constants/RouteConstants.cs
@@ -1,0 +1,76 @@
+namespace EssentialCSharp.Web.Constants;
+
+/// <summary>
+/// Centralized definition of application routes and their metadata.
+/// This constant provides a single source of truth for route paths,
+/// making it easier to maintain and update routes across the application.
+/// </summary>
+public static class RouteConstants
+{
+    /// <summary>
+    /// Static page routes that are not content pages (e.g., informational, utility pages).
+    /// Content pages are dynamically loaded from sitemap.json.
+    /// </summary>
+    public static class StaticPages
+    {
+        public const string Home = "/home";
+        public const string About = "/about";
+        public const string Guidelines = "/guidelines";
+        public const string Announcements = "/announcements";
+        public const string TermsOfService = "/termsofservice";
+    }
+
+    /// <summary>
+    /// Set of non-content route paths. Use this to determine if a requested path
+    /// is a static page (non-content) or a content page (from sitemap).
+    /// </summary>
+    public static readonly HashSet<string> NonContentRoutes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        StaticPages.Home,
+        StaticPages.About,
+        StaticPages.Guidelines,
+        StaticPages.Announcements,
+        StaticPages.TermsOfService
+    };
+
+    /// <summary>
+    /// SEO metadata for routes used in sitemap generation.
+    /// Maps route paths to their change frequency and priority values.
+    /// </summary>
+    public static class SeoMetadata
+    {
+        public enum ChangeFrequency
+        {
+            Always,
+            Hourly,
+            Daily,
+            Weekly,
+            Monthly,
+            Yearly,
+            Never
+        }
+
+        /// <summary>
+        /// Maps route paths to (ChangeFrequency, Priority) tuples for sitemap.xml generation.
+        /// Priority is a decimal value between 0.0 and 1.0 (0.5 is the default).
+        /// </summary>
+        public static readonly Dictionary<string, (ChangeFrequency, decimal)> RouteConfig =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                { StaticPages.Home, (ChangeFrequency.Monthly, 0.5m) },
+                { StaticPages.About, (ChangeFrequency.Monthly, 0.5m) },
+                { StaticPages.Guidelines, (ChangeFrequency.Monthly, 0.9m) },
+                { StaticPages.Announcements, (ChangeFrequency.Monthly, 0.5m) },
+                { StaticPages.TermsOfService, (ChangeFrequency.Yearly, 0.2m) }
+            };
+    }
+
+    /// <summary>
+    /// Determines if the given path represents a content page (from sitemap)
+    /// versus a static page (non-content).
+    /// </summary>
+    public static bool IsContentPage(string path)
+    {
+        return !NonContentRoutes.Contains(path);
+    }
+}

--- a/EssentialCSharp.Web/Constants/RouteConstants.cs
+++ b/EssentialCSharp.Web/Constants/RouteConstants.cs
@@ -1,15 +1,18 @@
+using System.Collections.Frozen;
+using DotnetSitemapGenerator;
+
 namespace EssentialCSharp.Web.Constants;
 
 /// <summary>
 /// Centralized definition of application routes and their metadata.
-/// This constant provides a single source of truth for route paths,
-/// making it easier to maintain and update routes across the application.
+/// This is the single source of truth for static page route paths.
+/// Update these whenever a static page is added, removed, or renamed.
 /// </summary>
 public static class RouteConstants
 {
     /// <summary>
     /// Static page routes that are not content pages (e.g., informational, utility pages).
-    /// Content pages are dynamically loaded from sitemap.json.
+    /// Content pages are dynamically discovered from sitemap.json.
     /// </summary>
     public static class StaticPages
     {
@@ -21,56 +24,36 @@ public static class RouteConstants
     }
 
     /// <summary>
-    /// Set of non-content route paths. Use this to determine if a requested path
-    /// is a static page (non-content) or a content page (from sitemap).
+    /// Immutable set of non-content route paths. Use to determine if a requested path
+    /// is a static page (non-content) rather than a content page (from sitemap).
     /// </summary>
-    public static readonly HashSet<string> NonContentRoutes = new(StringComparer.OrdinalIgnoreCase)
+    public static readonly FrozenSet<string> NonContentRoutes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
         StaticPages.Home,
         StaticPages.About,
         StaticPages.Guidelines,
         StaticPages.Announcements,
         StaticPages.TermsOfService
-    };
+    }.ToFrozenSet();
 
     /// <summary>
-    /// SEO metadata for routes used in sitemap generation.
-    /// Maps route paths to their change frequency and priority values.
+    /// SEO metadata for static routes used in sitemap.xml generation.
     /// </summary>
     public static class SeoMetadata
     {
-        public enum ChangeFrequency
-        {
-            Always,
-            Hourly,
-            Daily,
-            Weekly,
-            Monthly,
-            Yearly,
-            Never
-        }
-
         /// <summary>
-        /// Maps route paths to (ChangeFrequency, Priority) tuples for sitemap.xml generation.
-        /// Priority is a decimal value between 0.0 and 1.0 (0.5 is the default).
+        /// Immutable map of route paths to (ChangeFrequency, Priority) tuples.
+        /// Keys include the leading slash (e.g. "/home") to match how ASP.NET Core
+        /// exposes routes. Priority is 0.0–1.0; 0.5 is the sitemap default.
         /// </summary>
-        public static readonly Dictionary<string, (ChangeFrequency, decimal)> RouteConfig =
-            new(StringComparer.OrdinalIgnoreCase)
+        public static readonly FrozenDictionary<string, (ChangeFrequency Frequency, decimal Priority)> RouteConfig =
+            new Dictionary<string, (ChangeFrequency, decimal)>(StringComparer.OrdinalIgnoreCase)
             {
-                { StaticPages.Home, (ChangeFrequency.Monthly, 0.5m) },
-                { StaticPages.About, (ChangeFrequency.Monthly, 0.5m) },
-                { StaticPages.Guidelines, (ChangeFrequency.Monthly, 0.9m) },
+                { StaticPages.Home,          (ChangeFrequency.Monthly, 0.5m) },
+                { StaticPages.About,         (ChangeFrequency.Monthly, 0.5m) },
+                { StaticPages.Guidelines,    (ChangeFrequency.Monthly, 0.9m) },
                 { StaticPages.Announcements, (ChangeFrequency.Monthly, 0.5m) },
-                { StaticPages.TermsOfService, (ChangeFrequency.Yearly, 0.2m) }
-            };
-    }
-
-    /// <summary>
-    /// Determines if the given path represents a content page (from sitemap)
-    /// versus a static page (non-content).
-    /// </summary>
-    public static bool IsContentPage(string path)
-    {
-        return !NonContentRoutes.Contains(path);
+                { StaticPages.TermsOfService,(ChangeFrequency.Yearly,  0.2m) }
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/EssentialCSharp.Web/Constants/RouteConstants.cs
+++ b/EssentialCSharp.Web/Constants/RouteConstants.cs
@@ -34,7 +34,7 @@ public static class RouteConstants
         StaticPages.Guidelines,
         StaticPages.Announcements,
         StaticPages.TermsOfService
-    }.ToFrozenSet();
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// SEO metadata for static routes used in sitemap.xml generation.

--- a/EssentialCSharp.Web/Controllers/HomeController.cs
+++ b/EssentialCSharp.Web/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 using DotnetSitemapGenerator;
+using EssentialCSharp.Web.Constants;
 using EssentialCSharp.Web.Extensions;
 using EssentialCSharp.Web.Helpers;
 using EssentialCSharp.Web.Models;
@@ -48,7 +49,7 @@ public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment 
         }
     }
 
-    [Route("/TermsOfService",
+    [Route(RouteConstants.StaticPages.TermsOfService,
        Name = "TermsOfService")]
     public IActionResult TermsOfService()
     {
@@ -56,27 +57,27 @@ public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment 
         return View();
     }
 
-    [Route("/Announcements", Name = "Announcements")]
+    [Route(RouteConstants.StaticPages.Announcements, Name = "Announcements")]
     public IActionResult Announcements()
     {
         ViewBag.PageTitle = "Announcements";
         return View();
     }
 
-    [Route("/about", Name = "about")]
+    [Route(RouteConstants.StaticPages.About, Name = "about")]
     public IActionResult About()
     {
         ViewBag.PageTitle = "About";
         return View();
     }
 
-    [Route("/home", Name = "home")]
+    [Route(RouteConstants.StaticPages.Home, Name = "home")]
     public IActionResult Home()
     {
         return View();
     }
 
-    [Route("/guidelines", Name = "guidelines")]
+    [Route(RouteConstants.StaticPages.Guidelines, Name = "guidelines")]
     public IActionResult Guidelines()
     {
         ViewBag.PageTitle = "Coding Guidelines";

--- a/EssentialCSharp.Web/Helpers/SitemapXmlHelpers.cs
+++ b/EssentialCSharp.Web/Helpers/SitemapXmlHelpers.cs
@@ -75,25 +75,21 @@ public static class SitemapXmlHelpers
 
     private static ChangeFrequency GetChangeFrequencyForRoute(string route)
     {
-        var normalizedRoute = route.TrimStart('/').ToLowerInvariant();
-        
-        if (RouteConstants.SeoMetadata.RouteConfig.TryGetValue(normalizedRoute, out var config))
+        if (RouteConstants.SeoMetadata.RouteConfig.TryGetValue(route, out var config))
         {
-            return (ChangeFrequency)(int)config.Item1;
+            return config.Frequency;
         }
-        
+
         return ChangeFrequency.Monthly;
     }
 
     private static decimal GetPriorityForRoute(string route)
     {
-        var normalizedRoute = route.TrimStart('/').ToLowerInvariant();
-        
-        if (RouteConstants.SeoMetadata.RouteConfig.TryGetValue(normalizedRoute, out var config))
+        if (RouteConstants.SeoMetadata.RouteConfig.TryGetValue(route, out var config))
         {
-            return config.Item2;
+            return config.Priority;
         }
-        
+
         return 0.5M;
     }
 

--- a/EssentialCSharp.Web/Helpers/SitemapXmlHelpers.cs
+++ b/EssentialCSharp.Web/Helpers/SitemapXmlHelpers.cs
@@ -1,4 +1,5 @@
 using DotnetSitemapGenerator;
+using EssentialCSharp.Web.Constants;
 using EssentialCSharp.Web.Services;
 
 namespace EssentialCSharp.Web.Helpers;
@@ -74,26 +75,26 @@ public static class SitemapXmlHelpers
 
     private static ChangeFrequency GetChangeFrequencyForRoute(string route)
     {
-        return route.ToLowerInvariant() switch
+        var normalizedRoute = route.TrimStart('/').ToLowerInvariant();
+        
+        if (RouteConstants.SeoMetadata.RouteConfig.TryGetValue(normalizedRoute, out var config))
         {
-            "/termsofservice" => ChangeFrequency.Yearly,
-            "/announcements" => ChangeFrequency.Monthly,
-            "/guidelines" => ChangeFrequency.Monthly,
-            _ => ChangeFrequency.Monthly
-        };
+            return (ChangeFrequency)(int)config.Item1;
+        }
+        
+        return ChangeFrequency.Monthly;
     }
 
     private static decimal GetPriorityForRoute(string route)
     {
-        return route.ToLowerInvariant() switch
+        var normalizedRoute = route.TrimStart('/').ToLowerInvariant();
+        
+        if (RouteConstants.SeoMetadata.RouteConfig.TryGetValue(normalizedRoute, out var config))
         {
-            "/home" => 0.5M,
-            "/about" => 0.5M,
-            "/announcements" => 0.5M,
-            "/guidelines" => 0.9M,
-            "/termsofservice" => 0.2M,
-            _ => 0.5M
-        };
+            return config.Item2;
+        }
+        
+        return 0.5M;
     }
 
 }

--- a/EssentialCSharp.Web/Views/Home/Home.cshtml
+++ b/EssentialCSharp.Web/Views/Home/Home.cshtml
@@ -122,7 +122,7 @@
 
     <div class="row justify-content-center">
         <div class="col-auto">
-            <a class="btn btn-primary" href="/Announcements">
+            <a class="btn btn-primary" href="/announcements">
                 View All Announcements
             </a>
         </div>

--- a/EssentialCSharp.Web/src/components/SidebarPanel.vue
+++ b/EssentialCSharp.Web/src/components/SidebarPanel.vue
@@ -1,35 +1,11 @@
 <script setup>
 import { inject } from "vue";
 import TocTree from "./TocTree.vue";
+import { NAVIGATION_LINKS } from "../constants/routes.js";
 
 const shell = inject("shell");
 const currentPath = window.location.pathname.toLowerCase();
-const navLinks = [
-    {
-        href: "/home",
-        iconClass: "fas fa-home me-2",
-        label: "Home",
-        activePaths: ["/", "/home"]
-    },
-    {
-        href: "/about",
-        iconClass: "fas fa-book me-2",
-        label: "About",
-        activePaths: ["/about"]
-    },
-    {
-        href: "/guidelines",
-        iconClass: "fas fa-code me-2",
-        label: "Guidelines",
-        activePaths: ["/guidelines"]
-    },
-    {
-        href: "/announcements",
-        iconClass: "fas fa-bullhorn me-2",
-        label: "Announcements",
-        activePaths: ["/announcements"]
-    }
-];
+const navLinks = NAVIGATION_LINKS;
 
 function isActivePath(paths) {
     return paths.includes(currentPath);

--- a/EssentialCSharp.Web/src/components/SidebarPanel.vue
+++ b/EssentialCSharp.Web/src/components/SidebarPanel.vue
@@ -42,7 +42,7 @@ function isActivePath(paths) {
                 <div class="list-group list-group-flush d-md-none mb-3">
                     <a
                         v-for="navLink in navLinks"
-                        :key="navLink.href"
+                        :key="navLink.key"
                         :href="navLink.href"
                         class="list-group-item list-group-item-action"
                         :class="{ active: isActivePath(navLink.activePaths) }"

--- a/EssentialCSharp.Web/src/composables/useSiteShell.js
+++ b/EssentialCSharp.Web/src/composables/useSiteShell.js
@@ -1,5 +1,6 @@
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { useWindowSize } from "./useWindowSize.js";
+import { NON_CONTENT_ROUTES } from "../constants/routes.js";
 
 const SMALL_SCREEN_SIZE = 768;
 
@@ -71,7 +72,21 @@ export function useSiteShell() {
     const smallScreen = computed(() => (windowWidth.value || 0) < SMALL_SCREEN_SIZE);
     const currentPage = findCurrentPage([], tocData) ?? [];
     const chapterParentPage = currentPage.find((parent) => parent.level === 0) ?? null;
-    const isContentPage = computed(() => percentComplete.value !== null);
+    
+    /**
+     * Determines if the current page is a content page (from sitemap) or a static page.
+     * Checks against the NON_CONTENT_ROUTES array and falls back to percentComplete check
+     * for additional verification.
+     */
+    const isContentPage = computed(() => {
+        const currentPath = window.location.pathname.toLowerCase();
+        const isStaticPage = NON_CONTENT_ROUTES.some(route => 
+            currentPath === route.toLowerCase() || 
+            currentPath.startsWith(route.toLowerCase() + '/')
+        );
+        
+        return !isStaticPage && percentComplete.value !== null;
+    });
 
     for (const item of currentPage) {
         expandedTocs.add(item.key);

--- a/EssentialCSharp.Web/src/composables/useSiteShell.js
+++ b/EssentialCSharp.Web/src/composables/useSiteShell.js
@@ -1,6 +1,6 @@
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { useWindowSize } from "./useWindowSize.js";
-import { NON_CONTENT_ROUTES } from "../constants/routes.js";
+import { isContentPagePath } from "../constants/routes.js";
 
 const SMALL_SCREEN_SIZE = 768;
 
@@ -75,17 +75,11 @@ export function useSiteShell() {
     
     /**
      * Determines if the current page is a content page (from sitemap) or a static page.
-     * Checks against the NON_CONTENT_ROUTES array and falls back to percentComplete check
-     * for additional verification.
+     * Checks against the NON_CONTENT_ROUTES array via isContentPagePath and falls back
+     * to percentComplete check for additional verification that content data is loaded.
      */
     const isContentPage = computed(() => {
-        const currentPath = window.location.pathname.toLowerCase();
-        const isStaticPage = NON_CONTENT_ROUTES.some(route => 
-            currentPath === route.toLowerCase() || 
-            currentPath.startsWith(route.toLowerCase() + '/')
-        );
-        
-        return !isStaticPage && percentComplete.value !== null;
+        return isContentPagePath(window.location.pathname) && percentComplete.value !== null;
     });
 
     for (const item of currentPage) {

--- a/EssentialCSharp.Web/src/constants/routes.js
+++ b/EssentialCSharp.Web/src/constants/routes.js
@@ -1,0 +1,74 @@
+/**
+ * Centralized route constants for the frontend.
+ * Mirrors the backend RouteConstants to ensure consistency across frontend and backend.
+ * Update these whenever routes are added, removed, or changed.
+ */
+
+export const ROUTES = {
+    HOME: '/home',
+    ABOUT: '/about',
+    GUIDELINES: '/guidelines',
+    ANNOUNCEMENTS: '/announcements',
+    TERMS_OF_SERVICE: '/termsofservice'
+};
+
+/**
+ * Array of non-content route paths.
+ * Use with Array.includes() to determine if a path is a static page vs. a content page.
+ */
+export const NON_CONTENT_ROUTES = [
+    ROUTES.HOME,
+    ROUTES.ABOUT,
+    ROUTES.GUIDELINES,
+    ROUTES.ANNOUNCEMENTS,
+    ROUTES.TERMS_OF_SERVICE
+];
+
+/**
+ * Navigation link definitions for the sidebar.
+ * Each link includes href, label, icon class, and active path matching patterns.
+ */
+export const NAVIGATION_LINKS = [
+    {
+        href: ROUTES.HOME,
+        label: 'Home',
+        iconClass: 'fas fa-home me-2',
+        activePaths: ['/', ROUTES.HOME],
+        key: 'home'
+    },
+    {
+        href: ROUTES.ABOUT,
+        label: 'About',
+        iconClass: 'fas fa-book me-2',
+        activePaths: [ROUTES.ABOUT],
+        key: 'about'
+    },
+    {
+        href: ROUTES.GUIDELINES,
+        label: 'Guidelines',
+        iconClass: 'fas fa-code me-2',
+        activePaths: [ROUTES.GUIDELINES],
+        key: 'guidelines'
+    },
+    {
+        href: ROUTES.ANNOUNCEMENTS,
+        label: 'Announcements',
+        iconClass: 'fas fa-bullhorn me-2',
+        activePaths: [ROUTES.ANNOUNCEMENTS],
+        key: 'announcements'
+    }
+];
+
+/**
+ * Determines if the given path is a content page (from sitemap)
+ * versus a static page (non-content).
+ * @param {string} path - The path to check
+ * @returns {boolean} - True if path is a content page, false if static page
+ */
+export function isContentPagePath(path) {
+    const normalizedPath = path.toLowerCase();
+    return !NON_CONTENT_ROUTES.some(route => 
+        normalizedPath === route.toLowerCase() || 
+        normalizedPath.startsWith(route.toLowerCase() + '/')
+    );
+}

--- a/EssentialCSharp.Web/src/constants/routes.js
+++ b/EssentialCSharp.Web/src/constants/routes.js
@@ -27,6 +27,8 @@ export const NON_CONTENT_ROUTES = [
 /**
  * Navigation link definitions for the sidebar.
  * Each link includes href, label, icon class, and active path matching patterns.
+ * Note: ROUTES.TERMS_OF_SERVICE is intentionally excluded from this list —
+ * it is a legal page linked in the footer, not a primary navigation destination.
  */
 export const NAVIGATION_LINKS = [
     {


### PR DESCRIPTION
## Motivation

Hard-coded route strings were scattered across multiple frontend and backend files (`useSiteShell.js`, `SidebarPanel.vue`, `SitemapXmlHelpers.cs`, `HomeController.cs`), making route changes brittle and error-prone. Issue #747 specifically called out the `isContentPage` logic and suggested extracting routes into a constant and using `Array.includes()` for clarity.

## Approach

Two new constant files serve as the single source of truth per layer:

**Backend** -- `EssentialCSharp.Web/Constants/RouteConstants.cs`
- `StaticPages` inner class with `const string` values for each non-content route
- `NonContentRoutes` HashSet for O(1) membership checks
- `SeoMetadata.RouteConfig` dictionary mapping routes to `(ChangeFrequency, priority)` tuples, replacing the two switch expressions in `SitemapXmlHelpers.cs`

**Frontend** -- `EssentialCSharp.Web/src/constants/routes.js`
- `ROUTES` object with named route constants
- `NON_CONTENT_ROUTES` array for `Array.includes()`/`.some()` checks
- `NAVIGATION_LINKS` array (with icon class, label, activePaths) replacing the inline definition in `SidebarPanel.vue`
- `isContentPagePath()` helper function for reuse

**Consumers updated:**
- `useSiteShell.js` -- `isContentPage` now uses `NON_CONTENT_ROUTES.some()` as the primary check, with `percentComplete !== null` as a secondary guard
- `SidebarPanel.vue` -- imports `NAVIGATION_LINKS` instead of defining the array inline
- `SitemapXmlHelpers.cs` -- `GetChangeFrequencyForRoute` / `GetPriorityForRoute` use dictionary lookup instead of switch expressions
- `HomeController.cs` -- `[Route()]` attributes reference `RouteConstants.StaticPages` constants

## Notes

- The `percentComplete !== null` fallback is intentionally preserved in `isContentPage` so that pages not in the static list still correctly opt in/out of content-page features based on server-side data.
- Adding a new static page now requires updating only the two constant files; all consumers pick up the change automatically.

Closes #747