### PR TITLE
Enable NuGet audit on public feed without private feed access

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <ToolingPackagesVersion>1.1.1.19071</ToolingPackagesVersion>
     <AccessToNugetFeed Condition="'$(AccessToNugetFeed)' == ''">false</AccessToNugetFeed>
-    <!-- Disable NuGet vulnerability audit when the private feed is unavailable (e.g. CI without credentials).
-         NuGet audit queries all sources in nuget.config regardless of RestoreSources, causing NU1900 which is
-         escalated to an error by TreatWarningsAsErrors. -->
-    <NuGetAudit Condition="'$(AccessToNugetFeed)' != 'true'">false</NuGetAudit>
+    <!-- Enable NuGet vulnerability audit on public nuget.org feed. Restrict to 'nuget' source to avoid
+         NU1900 errors when the private Azure DevOps feed is unavailable (e.g. CI without credentials). -->
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditSources Condition="'$(AccessToNugetFeed)' != 'true'">nuget</NuGetAuditSources>
   </PropertyGroup>
   <ItemGroup Condition="$(AccessToNugetFeed)">
     <PackageVersion Include="ContentFeedNuget" Version="$(ToolingPackagesVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <ToolingPackagesVersion>1.1.1.19071</ToolingPackagesVersion>
     <AccessToNugetFeed Condition="'$(AccessToNugetFeed)' == ''">false</AccessToNugetFeed>
-    <!-- Enable NuGet vulnerability audit on public nuget.org feed. Restrict to 'nuget' source to avoid
-         NU1900 errors when the private Azure DevOps feed is unavailable (e.g. CI without credentials). -->
+    <!-- Enable NuGet vulnerability audit on public nuget.org feed. Restrict to nuget.org's service index
+         to avoid NU1900 errors when the private Azure DevOps feed is unavailable (e.g. CI without credentials). -->
     <NuGetAudit>true</NuGetAudit>
-    <NuGetAuditSources Condition="'$(AccessToNugetFeed)' != 'true'">nuget</NuGetAuditSources>
+    <NuGetAuditSources Condition="'$(AccessToNugetFeed)' != 'true'">https://api.nuget.org/v3/index.json</NuGetAuditSources>
   </PropertyGroup>
   <ItemGroup Condition="$(AccessToNugetFeed)">
     <PackageVersion Include="ContentFeedNuget" Version="$(ToolingPackagesVersion)" />

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ This guide will help you set up your local development environment for working o
 For basic browsing and UI development, no secrets are needed. The database connection and HCaptcha test keys are already configured in `appsettings.Development.json`.
 
 1. Clone the repository.
-2. If you have access to the private NuGet feed, set `<AccessToNugetFeed>true</AccessToNugetFeed>` in [Directory.Packages.props](../Directory.Packages.props).
+2. (Optional) If you have access to the private NuGet feed, set `<AccessToNugetFeed>true</AccessToNugetFeed>` in [Directory.Packages.props](../Directory.Packages.props) to include internal packages. Without this, the app runs with placeholder content but security audits still function.
 3. Run the project.
 
 > **Tip:** Use the [dotnet secret manager](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets#set-a-secret) for any secrets below:

--- a/nuget.config
+++ b/nuget.config
@@ -6,6 +6,10 @@
         <add key="nuget" value="https://api.nuget.org/v3/index.json" />
         <add key="EssentialCSharp" value="https://pkgs.dev.azure.com/intelliTect/_packaging/EssentialCSharp/nuget/v3/index.json" />
     </packageSources>
+    <auditSources>
+        <clear />
+        <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    </auditSources>
     <packageSourceMapping>
         <packageSource key="nuget">
             <package pattern="*" />


### PR DESCRIPTION
## Problem

NuGet audit was unconditionally disabled when the private Azure DevOps feed is unavailable — the default in CI environments without credentials. This creates a security gap where vulnerabilities in public packages go undetected during builds.

## Solution

- Enabled `NuGetAudit` unconditionally
- Added `NuGetAuditSources` property to restrict audit to the public `nuget` source when `AccessToNugetFeed != true`

This approach prevents NU1900 errors when the private feed is inaccessible while keeping security vulnerability checks active.

## Changes

- **Directory.Packages.props** — Set `NuGetAudit=true` and conditionally scope audit to the public nuget source in CI
- **docs/getting-started.md** — Clarified that the private feed is optional; security audit functions without it

## Impact

NuGet audit now runs in all CI paths (PR builds, CodeQL, deployments) and detects vulnerabilities in public packages, even without private feed credentials.