### PR TITLE
Make sitemap lastmod dates accurate for static and content routes

### DIFF
--- a/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
+++ b/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
@@ -246,6 +246,88 @@ public class SitemapXmlHelpersTests : IntegrationTestBase
         await Assert.That(siteMappingNode.LastModificationDate).IsNull();
     }
 
+    [Test]
+    public async Task GenerateSitemapXml_UsesLastModifiedDateFromStaticRouteLookup()
+    {
+        // Arrange
+        var baseUrl = "https://test.example.com/";
+        var homeLastModified = new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var staticRouteLastModifiedDates = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["/home"] = homeLastModified
+        };
+        var siteMappings = new List<SiteMapping>();
+
+        // Act
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappings,
+            routeConfigurationService,
+            baseUrl,
+            staticRouteLastModifiedDates,
+            out var nodes);
+
+        // Assert
+        var homeNode = nodes.First(node => node.Url.EndsWith("/home", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(homeNode.LastModificationDate).IsEqualTo(homeLastModified);
+    }
+
+    [Test]
+    public async Task GenerateSitemapXml_AppliesLastModifiedDateForAllMappedStaticRoutes()
+    {
+        // Arrange
+        var baseUrl = "https://test.example.com/";
+        var staticRouteLastModifiedDates = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["/home"] = new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+            ["/about"] = new DateTime(2025, 2, 3, 4, 5, 6, DateTimeKind.Utc),
+            ["/guidelines"] = new DateTime(2025, 3, 4, 5, 6, 7, DateTimeKind.Utc)
+        };
+        var siteMappings = new List<SiteMapping>();
+
+        // Act
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappings,
+            routeConfigurationService,
+            baseUrl,
+            staticRouteLastModifiedDates,
+            out var nodes);
+
+        // Assert
+        foreach ((var route, var expectedLastModified) in staticRouteLastModifiedDates)
+        {
+            var routeNode = nodes.First(node => node.Url.EndsWith(route, StringComparison.OrdinalIgnoreCase));
+            await Assert.That(routeNode.LastModificationDate).IsEqualTo(expectedLastModified);
+        }
+    }
+
+    [Test]
+    public async Task GenerateSitemapXml_UsesHomeLastModifiedDateForRootNode()
+    {
+        // Arrange
+        var baseUrl = "https://test.example.com/";
+        var homeLastModified = new DateTime(2025, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+        var staticRouteLastModifiedDates = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["/home"] = homeLastModified
+        };
+        var siteMappings = new List<SiteMapping>();
+
+        // Act
+        var routeConfigurationService = Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappings,
+            routeConfigurationService,
+            baseUrl,
+            staticRouteLastModifiedDates,
+            out var nodes);
+
+        // Assert
+        var rootNode = nodes.First(node => node.Url == baseUrl);
+        await Assert.That(rootNode.LastModificationDate).IsEqualTo(homeLastModified);
+    }
+
     private static SiteMapping CreateSiteMapping(
         int chapterNumber,
         int pageNumber,

--- a/EssentialCSharp.Web/Controllers/HomeController.cs
+++ b/EssentialCSharp.Web/Controllers/HomeController.cs
@@ -12,8 +12,18 @@ using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Controllers;
 
-public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment hostingEnvironment, ISiteMappingService siteMappingService, IHttpContextAccessor httpContextAccessor, IRouteConfigurationService routeConfigurationService, IOptions<SiteSettings> siteSettings) : BaseController(routeConfigurationService, httpContextAccessor)
+public partial class HomeController(ILogger<HomeController> logger, IWebHostEnvironment hostingEnvironment, ISiteMappingService siteMappingService, IHttpContextAccessor httpContextAccessor, IRouteConfigurationService routeConfigurationService, IOptions<SiteSettings> siteSettings) : BaseController(routeConfigurationService, httpContextAccessor)
 {
+    // Keep this map in sync with files that materially affect each route's rendered content.
+    private static readonly IReadOnlyDictionary<string, string[]> StaticRouteContentFiles = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["/home"] = ["Views\\Home\\Home.cshtml", "Models\\AnnouncementCatalog.cs"],
+        ["/about"] = ["Views\\Home\\About.cshtml"],
+        ["/announcements"] = ["Views\\Home\\Announcements.cshtml", "Models\\AnnouncementCatalog.cs"],
+        ["/termsofservice"] = ["Views\\Home\\TermsOfService.cshtml"],
+        ["/guidelines"] = ["Views\\Home\\Guidelines.cshtml", "Guidelines\\guidelines.json"]
+    };
+
     [EnableRateLimiting("content")]
     public IActionResult Index()
     {
@@ -95,9 +105,52 @@ public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment 
     [EnableRateLimiting("content")]
     public IActionResult SitemapXml()
     {
-        SitemapXmlHelpers.GenerateSitemapXml(siteMappingService.SiteMappings, RouteConfigurationService, siteSettings.Value.BaseUrl, out var nodes);
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappingService.SiteMappings,
+            RouteConfigurationService,
+            siteSettings.Value.BaseUrl,
+            GetStaticRouteLastModifiedDates(),
+            out var nodes);
         return new SitemapProvider().CreateSitemap(new SitemapModel(nodes));
     }
+
+    private Dictionary<string, DateTime> GetStaticRouteLastModifiedDates()
+    {
+        var routeLastModifiedDates = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+        foreach ((var route, var sourceFiles) in StaticRouteContentFiles)
+        {
+            DateTime? maxLastModified = null;
+            foreach (var sourceFile in sourceFiles)
+            {
+                var sourceFilePath = Path.Join(hostingEnvironment.ContentRootPath, sourceFile);
+                if (!System.IO.File.Exists(sourceFilePath))
+                {
+                    LogSitemapMappedFileMissing(logger, route, sourceFilePath);
+                    continue;
+                }
+
+                var sourceFileLastWriteTime = System.IO.File.GetLastWriteTimeUtc(sourceFilePath);
+                if (sourceFileLastWriteTime <= DateTime.UnixEpoch)
+                {
+                    continue;
+                }
+
+                maxLastModified = maxLastModified is null
+                    ? sourceFileLastWriteTime
+                    : sourceFileLastWriteTime > maxLastModified.Value ? sourceFileLastWriteTime : maxLastModified.Value;
+            }
+
+            if (maxLastModified is DateTime routeLastModified)
+            {
+                routeLastModifiedDates[route] = routeLastModified;
+            }
+        }
+
+        return routeLastModifiedDates;
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Sitemap mapped file missing for route {Route}: {FilePath}")]
+    private static partial void LogSitemapMappedFileMissing(ILogger<HomeController> logger, string route, string filePath);
 
     private string FlipPage(int currentChapter, int currentPage, bool next)
     {

--- a/EssentialCSharp.Web/Controllers/HomeController.cs
+++ b/EssentialCSharp.Web/Controllers/HomeController.cs
@@ -17,11 +17,11 @@ public partial class HomeController(ILogger<HomeController> logger, IWebHostEnvi
     // Keep this map in sync with files that materially affect each route's rendered content.
     private static readonly IReadOnlyDictionary<string, string[]> StaticRouteContentFiles = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
     {
-        ["/home"] = ["Views\\Home\\Home.cshtml", "Models\\AnnouncementCatalog.cs"],
-        ["/about"] = ["Views\\Home\\About.cshtml"],
-        ["/announcements"] = ["Views\\Home\\Announcements.cshtml", "Models\\AnnouncementCatalog.cs"],
-        ["/termsofservice"] = ["Views\\Home\\TermsOfService.cshtml"],
-        ["/guidelines"] = ["Views\\Home\\Guidelines.cshtml", "Guidelines\\guidelines.json"]
+        ["/home"] = [Path.Combine("Views", "Home", "Home.cshtml"), Path.Combine("Models", "AnnouncementCatalog.cs")],
+        ["/about"] = [Path.Combine("Views", "Home", "About.cshtml")],
+        ["/announcements"] = [Path.Combine("Views", "Home", "Announcements.cshtml"), Path.Combine("Models", "AnnouncementCatalog.cs")],
+        ["/termsofservice"] = [Path.Combine("Views", "Home", "TermsOfService.cshtml")],
+        ["/guidelines"] = [Path.Combine("Views", "Home", "Guidelines.cshtml"), Path.Combine("Guidelines", "guidelines.json")]
     };
 
     [EnableRateLimiting("content")]

--- a/EssentialCSharp.Web/Helpers/SitemapXmlHelpers.cs
+++ b/EssentialCSharp.Web/Helpers/SitemapXmlHelpers.cs
@@ -18,18 +18,37 @@ public static class SitemapXmlHelpers
         }
     }
 
-    public static void GenerateSitemapXml(IEnumerable<SiteMapping> siteMappings, IRouteConfigurationService routeConfigurationService, string baseUrl, out List<SitemapNode> nodes)
+    public static void GenerateSitemapXml(
+        IEnumerable<SiteMapping> siteMappings,
+        IRouteConfigurationService routeConfigurationService,
+        string baseUrl,
+        out List<SitemapNode> nodes) =>
+        GenerateSitemapXml(siteMappings, routeConfigurationService, baseUrl, staticRouteLastModifiedDates: null, out nodes);
+
+    public static void GenerateSitemapXml(
+        IEnumerable<SiteMapping> siteMappings,
+        IRouteConfigurationService routeConfigurationService,
+        string baseUrl,
+        IReadOnlyDictionary<string, DateTime>? staticRouteLastModifiedDates,
+        out List<SitemapNode> nodes)
     {
         // Routes should end up with leading slash
         baseUrl = baseUrl.TrimEnd('/');
 
         // Start with the root URL — no LastModificationDate: it doesn't change per-request
+        var rootNode = new SitemapNode($"{baseUrl}/")
+        {
+            ChangeFrequency = ChangeFrequency.Daily,
+            Priority = 1.0M
+        };
+
+        if (TryGetRouteLastModified(staticRouteLastModifiedDates, "/home") is DateTime homeLastModified)
+        {
+            rootNode.LastModificationDate = homeLastModified;
+        }
+
         nodes = new() {
-            new($"{baseUrl}/")
-            {
-                ChangeFrequency = ChangeFrequency.Daily,
-                Priority = 1.0M
-            }
+            rootNode
         };
 
         // Add routes dynamically discovered from controllers
@@ -44,11 +63,18 @@ public static class SitemapXmlHelpers
 
         foreach (var route in controllerRoutes)
         {
-            nodes.Add(new($"{baseUrl}{route}")
+            var node = new SitemapNode($"{baseUrl}{route}")
             {
                 ChangeFrequency = GetChangeFrequencyForRoute(route),
                 Priority = GetPriorityForRoute(route)
-            });
+            };
+
+            if (TryGetRouteLastModified(staticRouteLastModifiedDates, route) is DateTime routeLastModified)
+            {
+                node.LastModificationDate = routeLastModified;
+            }
+
+            nodes.Add(node);
         }
 
         // Add site mappings from content
@@ -67,6 +93,28 @@ public static class SitemapXmlHelpers
 
             return node;
         }));
+    }
+
+    private static DateTime? TryGetRouteLastModified(IReadOnlyDictionary<string, DateTime>? staticRouteLastModifiedDates, string route)
+    {
+        if (staticRouteLastModifiedDates is null)
+        {
+            return null;
+        }
+
+        var normalizedRoute = NormalizeRoute(route);
+        return staticRouteLastModifiedDates.TryGetValue(normalizedRoute, out var lastModified) ? lastModified : null;
+    }
+
+    private static string NormalizeRoute(string route)
+    {
+        route = route.Trim();
+        if (route == "/")
+        {
+            return route;
+        }
+
+        return $"/{route.TrimStart('/').ToLowerInvariant()}";
     }
 
     private static bool IsSitemapRoute(string route) =>


### PR DESCRIPTION
## Why
Sitemap `lastmod` was only reliable for chapter/content URLs. Static routes and the root entry were either missing `lastmod` or could drift from real content changes, which weakens sitemap freshness signals.

## What changed
- Added static-route `lastmod` support in sitemap generation via an optional route-to-date lookup.
- Set root `/` `lastmod` from `/home` when available.
- Wired `HomeController` to compute static route `lastmod` from source file timestamps.
- Expanded `/home` dependencies to include `Models/AnnouncementCatalog.cs` so announcement-content updates are reflected.
- Added a warning log when a mapped sitemap source file is missing to avoid silent drift.
- Added test coverage for mapped static route `lastmod` behavior while preserving chapter/root assertions.

## Notes for reviewers
- The static route dependency map is intentionally explicit (not auto-discovered) to keep behavior predictable and low-complexity.
- Unmapped routes still appear in sitemap; they simply omit `lastmod` until intentionally mapped.