### PR TITLE
Generate canonical and og:url from request path

### DIFF
--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -122,7 +122,7 @@ public partial class Program
         builder.Services.Configure<ForwardedHeadersOptions>(options =>
         {
             options.ForwardedHeaders =
-                ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
 
             // Only loopback proxies are allowed by default.
             // Clear that restriction because forwarders are enabled by explicit 

--- a/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
+++ b/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
@@ -16,11 +16,17 @@
         const string imageUrl = "https://essentialcsharp.com/images/icon.png";
         const string description = "Accelerate your development knowledge with C# expert Mark Michaelis and Benjamin Michaelis' free, online comprehensive C# tutorial and reference that is updated through C# 11.0";
         string title = $"Essential C#{(string.IsNullOrEmpty(ViewBag.PageTitle) ? string.Empty : $": {ViewBag.PageTitle}")}";
+        string canonicalPath = $"{Context.Request.PathBase}{Context.Request.Path}";
+        if (string.IsNullOrEmpty(canonicalPath))
+        {
+            canonicalPath = "/";
+        }
+        string canonicalUrl = $"{Context.Request.Scheme}://{Context.Request.Host}{canonicalPath}";
     }
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://essentialcsharp.com/" />
+    <meta property="og:url" content="@canonicalUrl" />
     <meta property="og:image:secure_url" content="@imageUrl" />
     <meta property="og:image" content="@imageUrl" />
     <meta name="twitter:image" content="@imageUrl" />
@@ -87,6 +93,7 @@
     <script src="~/js/hcaptcha-form.js" asp-append-version="true"></script>
     <!-- hCaptcha Script -->
     <script src="https://js.hcaptcha.com/1/api.js?render=explicit&onload=ecsOnHcaptchaLoad" async defer></script>
+    <link rel="canonical" href="@canonicalUrl" />
     @await RenderSectionAsync("HeadAppend", required: false)
 </head>
 <body>


### PR DESCRIPTION
## Why
The site metadata was inconsistent: og:url in _Layout.cshtml was hardcoded to the homepage, which did not match the actual route being viewed.

## What changed
- Generate a request-specific absolute URL in _Layout.cshtml from the current path.
- Use that URL for both <meta property="og:url"> and <link rel="canonical">.
- Include X-Forwarded-Host in forwarded header processing so host resolution is correct behind proxies.

## Notes for reviewers
- This keeps the existing chapter head injection behavior while providing consistent layout-level metadata across routes.
- Query strings remain excluded because canonical/OG values are path-based.
