### PR TITLE
fix: Replace footer javascript link with semantic button

### DIFF
--- a/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
+++ b/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
@@ -163,7 +163,7 @@
                 <a target="_blank" rel="noreferrer noopener" href="https://intellitect.com/about/privacy-policy/">Privacy</a>
             </div>
             <div class="col-12 col-md-auto align-self-end p-2">
-                <a href="javascript:void(0)" onclick="openConsentPreferences()">Cookie Preferences</a>
+                <button type="button" class="btn btn-link p-0 align-baseline" onclick="openConsentPreferences()">Cookie Preferences</button>
             </div>
             <div class="col-12 col-md-auto align-self-end p-2"><a asp-route="TermsOfService">Terms Of Service</a></div>
         </div>


### PR DESCRIPTION
## Why
The footer used an anchor with href="javascript:void(0)" for Cookie Preferences. That pattern is non-crawlable and not semantic for an in-page action.

## What changed
- Replaced the Cookie Preferences anchor with a semantic button that calls openConsentPreferences().
- Kept link-like visual behavior with Bootstrap classes: tn btn-link p-0 align-baseline.

## Notes
- Scope is limited to footer markup in EssentialCSharp.Web/Views/Shared/_Layout.cshtml.