### PR TITLE
fix: sitemap exclude API and parameterized routes

### DIFF
--- a/EssentialCSharp.Web.Tests/RouteConfigurationServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/RouteConfigurationServiceTests.cs
@@ -87,6 +87,7 @@ public class RouteConfigurationServiceTests
         await Assert.That(routes).Contains("guidelines");
         await Assert.That(routes).Contains("announcements");
         await Assert.That(routes).Contains("termsofservice");
+        await Assert.That(routes).Contains("mcp-setup");
     }
 
     [Test]

--- a/EssentialCSharp.Web.Tests/RouteConfigurationServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/RouteConfigurationServiceTests.cs
@@ -33,4 +33,79 @@ public class RouteConfigurationServiceTests
         await Assert.That(routes).Contains("announcements");
         await Assert.That(routes).Contains("termsofservice");
     }
+
+    [Test]
+    public async Task GetIndexableRoutes_ShouldExcludeApiControllerRoutes()
+    {
+        // Act
+        var routes = _Factory.InServiceScope(serviceProvider =>
+        {
+            var routeConfigurationService = serviceProvider.GetRequiredService<IRouteConfigurationService>();
+            return routeConfigurationService.GetIndexableRoutes().ToList();
+        });
+
+        // Assert - API routes should NOT be included
+        await Assert.That(routes).DoesNotContain(route => 
+            route.Contains("api/chat", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(routes).DoesNotContain(route => 
+            route.Contains("api/listingsourcecode", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(routes).DoesNotContain(route => 
+            route.Contains("api/mcptoken", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public async Task GetIndexableRoutes_ShouldExcludeParameterizedRoutes()
+    {
+        // Act
+        var routes = _Factory.InServiceScope(serviceProvider =>
+        {
+            var routeConfigurationService = serviceProvider.GetRequiredService<IRouteConfigurationService>();
+            return routeConfigurationService.GetIndexableRoutes().ToList();
+        });
+
+        // Assert - Routes with parameters should NOT be included
+        await Assert.That(routes).DoesNotContain(route => 
+            route.Contains('{'));
+        await Assert.That(routes).DoesNotContain(route => 
+            route.Contains("chapter", StringComparison.OrdinalIgnoreCase) && 
+            route.Contains('{'));
+    }
+
+    [Test]
+    public async Task GetIndexableRoutes_ShouldIncludeValidContentRoutes()
+    {
+        // Act
+        var routes = _Factory.InServiceScope(serviceProvider =>
+        {
+            var routeConfigurationService = serviceProvider.GetRequiredService<IRouteConfigurationService>();
+            return routeConfigurationService.GetIndexableRoutes().ToList();
+        });
+
+        // Assert - Valid content routes should be included
+        await Assert.That(routes).Contains("home");
+        await Assert.That(routes).Contains("about");
+        await Assert.That(routes).Contains("guidelines");
+        await Assert.That(routes).Contains("announcements");
+        await Assert.That(routes).Contains("termsofservice");
+    }
+
+    [Test]
+    public async Task GetStaticRoutes_StillReturnsAllRoutes_ForBackwardCompatibility()
+    {
+        // Act
+        var staticRoutes = _Factory.InServiceScope(serviceProvider =>
+        {
+            var routeConfigurationService = serviceProvider.GetRequiredService<IRouteConfigurationService>();
+            return routeConfigurationService.GetStaticRoutes().ToList();
+        });
+
+        var indexableRoutes = _Factory.InServiceScope(serviceProvider =>
+        {
+            var routeConfigurationService = serviceProvider.GetRequiredService<IRouteConfigurationService>();
+            return routeConfigurationService.GetIndexableRoutes().ToList();
+        });
+
+        // Assert - Static routes should include more than indexable routes (API routes, parameterized routes)
+        await Assert.That(staticRoutes.Count).IsGreaterThan(indexableRoutes.Count);
+    }
 }

--- a/EssentialCSharp.Web.Tests/RouteConfigurationServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/RouteConfigurationServiceTests.cs
@@ -44,13 +44,9 @@ public class RouteConfigurationServiceTests
             return routeConfigurationService.GetIndexableRoutes().ToList();
         });
 
-        // Assert - API routes should NOT be included
-        await Assert.That(routes).DoesNotContain(route => 
-            route.Contains("api/chat", StringComparison.OrdinalIgnoreCase));
-        await Assert.That(routes).DoesNotContain(route => 
-            route.Contains("api/listingsourcecode", StringComparison.OrdinalIgnoreCase));
-        await Assert.That(routes).DoesNotContain(route => 
-            route.Contains("api/mcptoken", StringComparison.OrdinalIgnoreCase));
+        // Assert - no indexable route should start with api/ (matches the actual filter behavior)
+        await Assert.That(routes).DoesNotContain(route =>
+            route.StartsWith("api/", StringComparison.OrdinalIgnoreCase));
     }
 
     [Test]

--- a/EssentialCSharp.Web.Tests/RouteParameterFilterTests.cs
+++ b/EssentialCSharp.Web.Tests/RouteParameterFilterTests.cs
@@ -1,16 +1,9 @@
 using EssentialCSharp.Web.Services;
-using System.Text.RegularExpressions;
 
 namespace EssentialCSharp.Web.Tests;
 
-/// <summary>
-/// Parameterized tests for the route parameter regex in RouteConfigurationService.
-/// Tests the pattern directly so any change to RouteParameterPattern is immediately caught.
-/// </summary>
 public class RouteParameterFilterTests
 {
-    private static readonly Regex s_regex = new(RouteConfigurationService.RouteParameterPattern);
-
     [Test]
     [Arguments("{chapter}")]
     [Arguments("{id:guid}")]
@@ -21,7 +14,7 @@ public class RouteParameterFilterTests
     [Arguments("[optional]")]
     [Arguments("area/[optional]/page")]
     public async Task RouteParameterRegex_MatchesParameterizedRoutes(string route)
-        => await Assert.That(s_regex.IsMatch(route)).IsTrue();
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch(route)).IsTrue();
 
     [Test]
     [Arguments("about")]
@@ -30,5 +23,5 @@ public class RouteParameterFilterTests
     [Arguments("api/listing")]
     [Arguments("")]
     public async Task RouteParameterRegex_DoesNotMatchStaticRoutes(string route)
-        => await Assert.That(s_regex.IsMatch(route)).IsFalse();
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch(route)).IsFalse();
 }

--- a/EssentialCSharp.Web.Tests/RouteParameterFilterTests.cs
+++ b/EssentialCSharp.Web.Tests/RouteParameterFilterTests.cs
@@ -1,12 +1,16 @@
 using EssentialCSharp.Web.Services;
+using System.Text.RegularExpressions;
 
 namespace EssentialCSharp.Web.Tests;
 
 /// <summary>
 /// Parameterized tests for the route parameter regex in RouteConfigurationService.
+/// Tests the pattern directly so any change to RouteParameterPattern is immediately caught.
 /// </summary>
 public class RouteParameterFilterTests
 {
+    private static readonly Regex s_regex = new(RouteConfigurationService.RouteParameterPattern);
+
     [Test]
     [Arguments("{chapter}")]
     [Arguments("{id:guid}")]
@@ -17,7 +21,7 @@ public class RouteParameterFilterTests
     [Arguments("[optional]")]
     [Arguments("area/[optional]/page")]
     public async Task RouteParameterRegex_MatchesParameterizedRoutes(string route)
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch(route)).IsTrue();
+        => await Assert.That(s_regex.IsMatch(route)).IsTrue();
 
     [Test]
     [Arguments("about")]
@@ -26,5 +30,5 @@ public class RouteParameterFilterTests
     [Arguments("api/listing")]
     [Arguments("")]
     public async Task RouteParameterRegex_DoesNotMatchStaticRoutes(string route)
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch(route)).IsFalse();
+        => await Assert.That(s_regex.IsMatch(route)).IsFalse();
 }

--- a/EssentialCSharp.Web.Tests/RouteParameterFilterTests.cs
+++ b/EssentialCSharp.Web.Tests/RouteParameterFilterTests.cs
@@ -3,65 +3,28 @@ using EssentialCSharp.Web.Services;
 namespace EssentialCSharp.Web.Tests;
 
 /// <summary>
-/// Unit tests for the route parameter regex in RouteConfigurationService.
-/// Calls RouteParameterRegex() directly to verify which patterns match (and should be
-/// excluded from the sitemap) vs. which do not (and should be included).
+/// Parameterized tests for the route parameter regex in RouteConfigurationService.
 /// </summary>
 public class RouteParameterFilterTests
 {
-    // --- patterns that SHOULD match (route is parameterised → excluded from sitemap) ---
+    [Test]
+    [Arguments("{chapter}")]
+    [Arguments("{id:guid}")]
+    [Arguments("{id?}")]
+    [Arguments("{action=Index}")]
+    [Arguments("{*catchall}")]
+    [Arguments("chapter/{chapter}/listing/{listing}")]
+    [Arguments("[optional]")]
+    [Arguments("area/[optional]/page")]
+    public async Task RouteParameterRegex_MatchesParameterizedRoutes(string route)
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch(route)).IsTrue();
 
     [Test]
-    public async Task RouteParameterRegex_MatchesSimpleCurlyBraceParameter()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{chapter}")).IsTrue();
-
-    [Test]
-    public async Task RouteParameterRegex_MatchesConstrainedParameter()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{id:guid}")).IsTrue();
-
-    [Test]
-    public async Task RouteParameterRegex_MatchesOptionalParameter()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{id?}")).IsTrue();
-
-    [Test]
-    public async Task RouteParameterRegex_MatchesParameterWithDefault()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{action=Index}")).IsTrue();
-
-    [Test]
-    public async Task RouteParameterRegex_MatchesCatchAllParameter()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{*catchall}")).IsTrue();
-
-    [Test]
-    public async Task RouteParameterRegex_MatchesParameterEmbeddedInPath()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("chapter/{chapter}/listing/{listing}")).IsTrue();
-
-    [Test]
-    public async Task RouteParameterRegex_MatchesSquareBracketSegment()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("[optional]")).IsTrue();
-
-    [Test]
-    public async Task RouteParameterRegex_MatchesSquareBracketEmbeddedInPath()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("area/[optional]/page")).IsTrue();
-
-    // --- patterns that should NOT match (static route → eligible for sitemap) ---
-
-    [Test]
-    public async Task RouteParameterRegex_DoesNotMatchBareWord()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("about")).IsFalse();
-
-    [Test]
-    public async Task RouteParameterRegex_DoesNotMatchHyphenatedRoute()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("mcp-setup")).IsFalse();
-
-    [Test]
-    public async Task RouteParameterRegex_DoesNotMatchStaticMultiSegmentPath()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("identity/account/login")).IsFalse();
-
-    [Test]
-    public async Task RouteParameterRegex_DoesNotMatchApiPrefixAlone()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("api/listing")).IsFalse();
-
-    [Test]
-    public async Task RouteParameterRegex_DoesNotMatchEmptyString()
-        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch(string.Empty)).IsFalse();
+    [Arguments("about")]
+    [Arguments("mcp-setup")]
+    [Arguments("identity/account/login")]
+    [Arguments("api/listing")]
+    [Arguments("")]
+    public async Task RouteParameterRegex_DoesNotMatchStaticRoutes(string route)
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch(route)).IsFalse();
 }

--- a/EssentialCSharp.Web.Tests/RouteParameterFilterTests.cs
+++ b/EssentialCSharp.Web.Tests/RouteParameterFilterTests.cs
@@ -1,0 +1,67 @@
+using EssentialCSharp.Web.Services;
+
+namespace EssentialCSharp.Web.Tests;
+
+/// <summary>
+/// Unit tests for the route parameter regex in RouteConfigurationService.
+/// Calls RouteParameterRegex() directly to verify which patterns match (and should be
+/// excluded from the sitemap) vs. which do not (and should be included).
+/// </summary>
+public class RouteParameterFilterTests
+{
+    // --- patterns that SHOULD match (route is parameterised → excluded from sitemap) ---
+
+    [Test]
+    public async Task RouteParameterRegex_MatchesSimpleCurlyBraceParameter()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{chapter}")).IsTrue();
+
+    [Test]
+    public async Task RouteParameterRegex_MatchesConstrainedParameter()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{id:guid}")).IsTrue();
+
+    [Test]
+    public async Task RouteParameterRegex_MatchesOptionalParameter()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{id?}")).IsTrue();
+
+    [Test]
+    public async Task RouteParameterRegex_MatchesParameterWithDefault()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{action=Index}")).IsTrue();
+
+    [Test]
+    public async Task RouteParameterRegex_MatchesCatchAllParameter()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("{*catchall}")).IsTrue();
+
+    [Test]
+    public async Task RouteParameterRegex_MatchesParameterEmbeddedInPath()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("chapter/{chapter}/listing/{listing}")).IsTrue();
+
+    [Test]
+    public async Task RouteParameterRegex_MatchesSquareBracketSegment()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("[optional]")).IsTrue();
+
+    [Test]
+    public async Task RouteParameterRegex_MatchesSquareBracketEmbeddedInPath()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("area/[optional]/page")).IsTrue();
+
+    // --- patterns that should NOT match (static route → eligible for sitemap) ---
+
+    [Test]
+    public async Task RouteParameterRegex_DoesNotMatchBareWord()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("about")).IsFalse();
+
+    [Test]
+    public async Task RouteParameterRegex_DoesNotMatchHyphenatedRoute()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("mcp-setup")).IsFalse();
+
+    [Test]
+    public async Task RouteParameterRegex_DoesNotMatchStaticMultiSegmentPath()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("identity/account/login")).IsFalse();
+
+    [Test]
+    public async Task RouteParameterRegex_DoesNotMatchApiPrefixAlone()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch("api/listing")).IsFalse();
+
+    [Test]
+    public async Task RouteParameterRegex_DoesNotMatchEmptyString()
+        => await Assert.That(RouteConfigurationService.RouteParameterRegex().IsMatch(string.Empty)).IsFalse();
+}

--- a/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
+++ b/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
@@ -49,11 +49,8 @@ public class SitemapXmlHelpersTests
 
         var allUrls = nodes.Select(n => n.Url).ToList();
 
-        // Verify no API routes are included
+        // Verify no API routes are included (assert on the /api/ pattern, not specific controller names)
         await Assert.That(allUrls).DoesNotContain(url => url.Contains("/api/", StringComparison.OrdinalIgnoreCase));
-        await Assert.That(allUrls).DoesNotContain(url => url.Contains("chat", StringComparison.OrdinalIgnoreCase));
-        await Assert.That(allUrls).DoesNotContain(url => url.Contains("listingsourcecode", StringComparison.OrdinalIgnoreCase));
-        await Assert.That(allUrls).DoesNotContain(url => url.Contains("mcptoken", StringComparison.OrdinalIgnoreCase));
     }
 
     [Test]

--- a/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
+++ b/EssentialCSharp.Web.Tests/SitemapXmlHelpersTests.cs
@@ -33,6 +33,51 @@ public class SitemapXmlHelpersTests
     }
 
     [Test]
+    public async Task GenerateSitemapXml_DoesNotIncludeApiRoutes()
+    {
+        // Arrange
+        var siteMappings = new List<SiteMapping> { CreateSiteMapping(1, 1, true) };
+        var baseUrl = "https://test.example.com/";
+
+        // Act & Assert
+        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappings,
+            routeConfigurationService,
+            baseUrl,
+            out var nodes);
+
+        var allUrls = nodes.Select(n => n.Url).ToList();
+
+        // Verify no API routes are included
+        await Assert.That(allUrls).DoesNotContain(url => url.Contains("/api/", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(allUrls).DoesNotContain(url => url.Contains("chat", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(allUrls).DoesNotContain(url => url.Contains("listingsourcecode", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(allUrls).DoesNotContain(url => url.Contains("mcptoken", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public async Task GenerateSitemapXml_DoesNotIncludeParameterizedRoutes()
+    {
+        // Arrange
+        var siteMappings = new List<SiteMapping> { CreateSiteMapping(1, 1, true) };
+        var baseUrl = "https://test.example.com/";
+
+        // Act & Assert
+        var routeConfigurationService = _Factory.Services.GetRequiredService<IRouteConfigurationService>();
+        SitemapXmlHelpers.GenerateSitemapXml(
+            siteMappings,
+            routeConfigurationService,
+            baseUrl,
+            out var nodes);
+
+        var allUrls = nodes.Select(n => n.Url).ToList();
+
+        // Verify no parameterized routes (with {}) are included
+        await Assert.That(allUrls).DoesNotContain(url => url.Contains('{'));
+    }
+
+    [Test]
     public async Task EnsureSitemapHealthy_WithMultipleCanonicalLinksForSamePage_ThrowsException()
     {
         // Arrange - Two mappings for the same chapter/page both marked as canonical

--- a/EssentialCSharp.Web/Helpers/SitemapXmlHelpers.cs
+++ b/EssentialCSharp.Web/Helpers/SitemapXmlHelpers.cs
@@ -32,12 +32,9 @@ public static class SitemapXmlHelpers
             }
         };
 
-        // Add routes dynamically discovered from controllers
-        var allRoutes = routeConfigurationService.GetStaticRoutes();
+        // Add routes dynamically discovered from controllers (only indexable routes)
+        var allRoutes = routeConfigurationService.GetIndexableRoutes();
         var controllerRoutes = allRoutes
-            .Where(route => !route.Contains("error", StringComparison.OrdinalIgnoreCase))
-            .Where(route => !route.Contains("index", StringComparison.OrdinalIgnoreCase))
-            .Where(route => !route.Contains("identity", StringComparison.OrdinalIgnoreCase))
             .Where(route => !IsSitemapRoute(route))
             .Select(route => $"/{route}")
             .ToList();

--- a/EssentialCSharp.Web/Properties/AssemblyInfo.cs
+++ b/EssentialCSharp.Web/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("EssentialCSharp.Web.Tests")]

--- a/EssentialCSharp.Web/Properties/AssemblyInfo.cs
+++ b/EssentialCSharp.Web/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("EssentialCSharp.Web.Tests")]

--- a/EssentialCSharp.Web/Services/IRouteConfigurationService.cs
+++ b/EssentialCSharp.Web/Services/IRouteConfigurationService.cs
@@ -3,4 +3,5 @@ namespace EssentialCSharp.Web.Services;
 public interface IRouteConfigurationService
 {
     IReadOnlySet<string> GetStaticRoutes();
+    IReadOnlySet<string> GetIndexableRoutes();
 }

--- a/EssentialCSharp.Web/Services/RouteConfigurationService.cs
+++ b/EssentialCSharp.Web/Services/RouteConfigurationService.cs
@@ -3,10 +3,10 @@ using System.Text.RegularExpressions;
 
 namespace EssentialCSharp.Web.Services;
 
-public class RouteConfigurationService : IRouteConfigurationService
+public partial class RouteConfigurationService : IRouteConfigurationService
 {
-    private static readonly Regex s_routeParameterRegex =
-        new(@"\{[^}]+\}|\[[^\]]+\]", RegexOptions.Compiled);
+    [GeneratedRegex(@"\{[^}]+\}|\[[^\]]+\]")]
+    internal static partial Regex RouteParameterRegex();
 
     private readonly IActionDescriptorCollectionProvider _ActionDescriptorCollectionProvider;
     private readonly HashSet<string> _StaticRoutes;
@@ -75,7 +75,7 @@ public class RouteConfigurationService : IRouteConfigurationService
     {
         return _StaticRoutes
             .Where(route => !route.StartsWith("api/", StringComparison.OrdinalIgnoreCase))
-            .Where(route => !s_routeParameterRegex.IsMatch(route))
+            .Where(route => !RouteParameterRegex().IsMatch(route))
             .Where(route => !route.Contains("identity", StringComparison.OrdinalIgnoreCase))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }

--- a/EssentialCSharp.Web/Services/RouteConfigurationService.cs
+++ b/EssentialCSharp.Web/Services/RouteConfigurationService.cs
@@ -5,8 +5,10 @@ namespace EssentialCSharp.Web.Services;
 
 public partial class RouteConfigurationService : IRouteConfigurationService
 {
-    [GeneratedRegex(@"\{[^}]+\}|\[[^\]]+\]")]
-    internal static partial Regex RouteParameterRegex();
+    [GeneratedRegex(RouteParameterPattern)]
+    private static partial Regex RouteParameterRegex();
+
+    public const string RouteParameterPattern = @"\{[^}]+\}|\[[^\]]+\]";
 
     private readonly IActionDescriptorCollectionProvider _ActionDescriptorCollectionProvider;
     private readonly HashSet<string> _StaticRoutes;

--- a/EssentialCSharp.Web/Services/RouteConfigurationService.cs
+++ b/EssentialCSharp.Web/Services/RouteConfigurationService.cs
@@ -1,4 +1,7 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using System.Text.RegularExpressions;
 
 namespace EssentialCSharp.Web.Services;
 
@@ -6,16 +9,23 @@ public class RouteConfigurationService : IRouteConfigurationService
 {
     private readonly IActionDescriptorCollectionProvider _ActionDescriptorCollectionProvider;
     private readonly HashSet<string> _StaticRoutes;
+    private readonly HashSet<string> _IndexableRoutes;
 
     public RouteConfigurationService(IActionDescriptorCollectionProvider actionDescriptorCollectionProvider)
     {
         _ActionDescriptorCollectionProvider = actionDescriptorCollectionProvider;
         _StaticRoutes = ExtractStaticRoutes();
+        _IndexableRoutes = ExtractIndexableRoutes();
     }
 
     public IReadOnlySet<string> GetStaticRoutes()
     {
         return _StaticRoutes;
+    }
+
+    public IReadOnlySet<string> GetIndexableRoutes()
+    {
+        return _IndexableRoutes;
     }
 
     private HashSet<string> ExtractStaticRoutes()
@@ -59,4 +69,83 @@ public class RouteConfigurationService : IRouteConfigurationService
 
         return routes;
     }
+
+    private HashSet<string> ExtractIndexableRoutes()
+    {
+        var indexableRoutes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        
+        // Get all action descriptors
+        var actionDescriptors = _ActionDescriptorCollectionProvider.ActionDescriptors.Items;
+        
+        foreach (var actionDescriptor in actionDescriptors)
+        {
+            // Skip if controller is marked with [ApiController]
+            if (IsApiController(actionDescriptor))
+                continue;
+
+            // Look for route attributes
+            if (actionDescriptor.AttributeRouteInfo?.Template != null)
+            {
+                string template = actionDescriptor.AttributeRouteInfo.Template;
+                
+                // Skip routes with parameters (e.g., {chapter}, {id:guid}, [optional])
+                if (ContainsRouteParameters(template))
+                    continue;
+                
+                // Skip routes starting with /api/
+                if (template.StartsWith("/api/", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                
+                // Remove leading slash and add to our set
+                string routePath = template.TrimStart('/').ToLowerInvariant();
+                indexableRoutes.Add(routePath);
+            }
+
+            // Skip the default fallback route (Index action in HomeController)
+            if (actionDescriptor.RouteValues.TryGetValue("action", out var action) && action == "Index")
+                continue;
+
+            // Skip Error actions
+            if (action == "Error")
+                continue;
+
+            // For actions without attribute routes, use conventional routing
+            if (actionDescriptor.AttributeRouteInfo?.Template == null &&
+                actionDescriptor.RouteValues.TryGetValue("action", out var actionName) &&
+                actionDescriptor.RouteValues.TryGetValue("controller", out var controllerName) &&
+                controllerName?.Equals("Home", StringComparison.OrdinalIgnoreCase) == true &&
+                actionName != null)
+            {
+                // Use the action name directly as the route
+                indexableRoutes.Add(actionName.ToLowerInvariant());
+            }
+        }
+
+        return indexableRoutes;
+    }
+
+    private static bool IsApiController(ActionDescriptor actionDescriptor)
+    {
+        // Check for [ApiController] attribute
+        if (actionDescriptor.EndpointMetadata?.OfType<ApiControllerAttribute>().Any() == true)
+            return true;
+        
+        // Check if controller inherits from ControllerBase (not Controller)
+        if (actionDescriptor.RouteValues.TryGetValue("controller", out var controllerName))
+        {
+            // Known API controllers
+            var apiControllers = new[] { "ListingSourceCode", "Chat", "McpToken", "MCP" };
+            if (apiControllers.Contains(controllerName, StringComparer.OrdinalIgnoreCase))
+                return true;
+        }
+        
+        return false;
+    }
+
+    private static bool ContainsRouteParameters(string template)
+    {
+        // Match {param}, {param:constraint}, [optional], etc.
+        return Regex.IsMatch(template, @"\{[^}]+\}|\[[^\]]+\]");
+    }
 }
+

--- a/EssentialCSharp.Web/Services/RouteConfigurationService.cs
+++ b/EssentialCSharp.Web/Services/RouteConfigurationService.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using System.Text.RegularExpressions;
 
@@ -7,6 +5,9 @@ namespace EssentialCSharp.Web.Services;
 
 public class RouteConfigurationService : IRouteConfigurationService
 {
+    private static readonly Regex s_routeParameterRegex =
+        new(@"\{[^}]+\}|\[[^\]]+\]", RegexOptions.Compiled);
+
     private readonly IActionDescriptorCollectionProvider _ActionDescriptorCollectionProvider;
     private readonly HashSet<string> _StaticRoutes;
     private readonly HashSet<string> _IndexableRoutes;
@@ -72,80 +73,11 @@ public class RouteConfigurationService : IRouteConfigurationService
 
     private HashSet<string> ExtractIndexableRoutes()
     {
-        var indexableRoutes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        
-        // Get all action descriptors
-        var actionDescriptors = _ActionDescriptorCollectionProvider.ActionDescriptors.Items;
-        
-        foreach (var actionDescriptor in actionDescriptors)
-        {
-            // Skip if controller is marked with [ApiController]
-            if (IsApiController(actionDescriptor))
-                continue;
-
-            // Look for route attributes
-            if (actionDescriptor.AttributeRouteInfo?.Template != null)
-            {
-                string template = actionDescriptor.AttributeRouteInfo.Template;
-                
-                // Skip routes with parameters (e.g., {chapter}, {id:guid}, [optional])
-                if (ContainsRouteParameters(template))
-                    continue;
-                
-                // Skip routes starting with /api/
-                if (template.StartsWith("/api/", StringComparison.OrdinalIgnoreCase))
-                    continue;
-                
-                // Remove leading slash and add to our set
-                string routePath = template.TrimStart('/').ToLowerInvariant();
-                indexableRoutes.Add(routePath);
-            }
-
-            // Skip the default fallback route (Index action in HomeController)
-            if (actionDescriptor.RouteValues.TryGetValue("action", out var action) && action == "Index")
-                continue;
-
-            // Skip Error actions
-            if (action == "Error")
-                continue;
-
-            // For actions without attribute routes, use conventional routing
-            if (actionDescriptor.AttributeRouteInfo?.Template == null &&
-                actionDescriptor.RouteValues.TryGetValue("action", out var actionName) &&
-                actionDescriptor.RouteValues.TryGetValue("controller", out var controllerName) &&
-                controllerName?.Equals("Home", StringComparison.OrdinalIgnoreCase) == true &&
-                actionName != null)
-            {
-                // Use the action name directly as the route
-                indexableRoutes.Add(actionName.ToLowerInvariant());
-            }
-        }
-
-        return indexableRoutes;
-    }
-
-    private static bool IsApiController(ActionDescriptor actionDescriptor)
-    {
-        // Check for [ApiController] attribute
-        if (actionDescriptor.EndpointMetadata?.OfType<ApiControllerAttribute>().Any() == true)
-            return true;
-        
-        // Check if controller inherits from ControllerBase (not Controller)
-        if (actionDescriptor.RouteValues.TryGetValue("controller", out var controllerName))
-        {
-            // Known API controllers
-            var apiControllers = new[] { "ListingSourceCode", "Chat", "McpToken", "MCP" };
-            if (apiControllers.Contains(controllerName, StringComparer.OrdinalIgnoreCase))
-                return true;
-        }
-        
-        return false;
-    }
-
-    private static bool ContainsRouteParameters(string template)
-    {
-        // Match {param}, {param:constraint}, [optional], etc.
-        return Regex.IsMatch(template, @"\{[^}]+\}|\[[^\]]+\]");
+        return _StaticRoutes
+            .Where(route => !route.StartsWith("api/", StringComparison.OrdinalIgnoreCase))
+            .Where(route => !s_routeParameterRegex.IsMatch(route))
+            .Where(route => !route.Contains("identity", StringComparison.OrdinalIgnoreCase))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 }
 

--- a/EssentialCSharp.Web/Services/RouteConfigurationService.cs
+++ b/EssentialCSharp.Web/Services/RouteConfigurationService.cs
@@ -5,10 +5,8 @@ namespace EssentialCSharp.Web.Services;
 
 public partial class RouteConfigurationService : IRouteConfigurationService
 {
-    [GeneratedRegex(RouteParameterPattern)]
-    private static partial Regex RouteParameterRegex();
-
-    public const string RouteParameterPattern = @"\{[^}]+\}|\[[^\]]+\]";
+    [GeneratedRegex(@"\{[^}]+\}|\[[^\]]+\]")]
+    public static partial Regex RouteParameterRegex();
 
     private readonly IActionDescriptorCollectionProvider _ActionDescriptorCollectionProvider;
     private readonly HashSet<string> _StaticRoutes;


### PR DESCRIPTION
## Motivation

The sitemap currently includes non-indexable routes such as `/api/listingsourcecode/*`, `/api/chat/*`, and parameterized templates like `/api/listingsourcecode/chapter/{chapter}/listing/{listing}`. These are API endpoints that return JSON or template routes with unfillable placeholders -- not real user-facing pages.

Including them wastes crawl budget, creates soft-404 signals, and can weaken site quality signals for search engines.

## Approach

Adds `GetIndexableRoutes()` to `IRouteConfigurationService` alongside the existing `GetStaticRoutes()`. The implementation derives indexable routes from the already-computed static route set using three string-level filters:

1. **`/api/` prefix** -- drops all API-prefixed routes
2. **Route parameter regex** -- drops routes containing `{param}` or `{param:constraint}` syntax (cached as `static readonly` to avoid repeated construction)
3. **Identity area** -- drops routes containing `identity` (Razor Pages under `/Identity/Account/*`)

`GetStaticRoutes()` is unchanged for backward compatibility (used by navigation UI). `SitemapXmlHelpers.GenerateSitemapXml()` now calls `GetIndexableRoutes()`, and redundant inline filters are removed.

## Tests added

- `GetIndexableRoutes_ShouldExcludeApiControllerRoutes`
- `GetIndexableRoutes_ShouldExcludeParameterizedRoutes`
- `GetIndexableRoutes_ShouldIncludeValidContentRoutes` (including `mcp-setup`)
- `GetStaticRoutes_StillReturnsAllRoutes_ForBackwardCompatibility`
- `GenerateSitemapXml_DoesNotIncludeApiRoutes` (asserts on `/api/` prefix pattern)
- `GenerateSitemapXml_DoesNotIncludeParameterizedRoutes`