### PR TITLE
fix(auth): honor ASPNETCORE_FORWARDEDHEADERS_ENABLED for ACA

### DIFF
--- a/EssentialCSharp.Web/Extensions/IServiceCollectionExtensions.cs
+++ b/EssentialCSharp.Web/Extensions/IServiceCollectionExtensions.cs
@@ -18,6 +18,12 @@ public static class IServiceCollectionExtensions
 
     public static void AddTrustedForwardedHeaders(this IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
     {
+        // When ASPNETCORE_FORWARDEDHEADERS_ENABLED=true (recommended for Azure Container Apps),
+        // ASP.NET Core's built-in startup filter handles ForwardedHeaders with all proxies trusted.
+        // Skip manual configuration to avoid a conflicting no-trusted-proxies throw on startup.
+        if (string.Equals(configuration["ASPNETCORE_FORWARDEDHEADERS_ENABLED"], "true", StringComparison.OrdinalIgnoreCase))
+            return;
+
         services.Configure<ForwardedHeadersOptions>(options =>
         {
             options.ForwardedHeaders =
@@ -37,7 +43,8 @@ public static class IServiceCollectionExtensions
                 {
                     throw new InvalidOperationException(
                         "Forwarded headers are enabled but no trusted proxies are configured. " +
-                        "Set ForwardedHeaders:TrustedProxyCidrs or ForwardedHeaders:TrustedProxies.");
+                        "Set ForwardedHeaders:TrustedProxyCidrs or ForwardedHeaders:TrustedProxies, " +
+                        "or set ASPNETCORE_FORWARDEDHEADERS_ENABLED=true for platform-managed proxies (e.g. Azure Container Apps).");
                 }
                 return;
             }

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -481,7 +481,12 @@ public partial class Program
                     }
                 });
             });
-            app.UseForwardedHeaders();
+            // Skip manual UseForwardedHeaders when ASPNETCORE_FORWARDEDHEADERS_ENABLED=true;
+            // the built-in startup filter already called it before this pipeline runs.
+            if (!string.Equals(app.Configuration["ASPNETCORE_FORWARDEDHEADERS_ENABLED"], "true", StringComparison.OrdinalIgnoreCase))
+            {
+                app.UseForwardedHeaders();
+            }
 
             // Build dynamic CSP — TryDotNet origin comes from runtime config
             string? tryDotNetOrigin = app.Configuration["TryDotNet:Origin"];
@@ -532,7 +537,10 @@ public partial class Program
         else
         {
             app.UseDeveloperExceptionPage();
-            app.UseForwardedHeaders();
+            if (!string.Equals(app.Configuration["ASPNETCORE_FORWARDEDHEADERS_ENABLED"], "true", StringComparison.OrdinalIgnoreCase))
+            {
+                app.UseForwardedHeaders();
+            }
         }
 
         app.MapHealthChecks("/health").DisableRateLimiting();


### PR DESCRIPTION
## Why
GitHub OAuth login on dev was generating an `http://` callback URL and failing with `redirect_uri is not associated with this application`. The deployment now uses `ASPNETCORE_FORWARDEDHEADERS_ENABLED=true`, so app-level forwarded-header setup must not conflict with ASP.NET Core's built-in handling.

## What changed
- `AddTrustedForwardedHeaders` now exits early when `ASPNETCORE_FORWARDEDHEADERS_ENABLED=true`.
- `Program.cs` skips manual `app.UseForwardedHeaders()` when that env var is enabled to avoid redundant middleware execution.
- Updated the forwarded-header configuration error message to document the env-var-based option for platform-managed proxies like Azure Container Apps.

## Notes for reviewers
This keeps the existing explicit CIDR path intact for environments that use `ForwardedHeaders:TrustedProxyCidrs`/`TrustedProxies`, while making ACA's env-var path safe and non-conflicting.