### PR TITLE
fix: streaming textdone events

### DIFF
--- a/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
@@ -250,18 +250,39 @@ public partial class AIChatService : IChatCompletionService
             }
             else if (update is StreamingResponseErrorUpdate errorUpdate)
             {
+                LogStreamingResponseErrorUpdate(
+                    _Logger,
+                    currentLegResponseId,
+                    errorUpdate.Code ?? "unknown",
+                    errorUpdate.Message ?? "no message provided");
                 throw new ChatBackendUnavailableException(
                     $"Streaming response error: {errorUpdate.Code ?? "unknown"} - {errorUpdate.Message ?? "no message provided"}",
                     errorCode: "stream_response_error");
             }
             else if (update is StreamingResponseFailedUpdate failedUpdate)
             {
+                LogStreamingResponseTerminalUpdate(
+                    _Logger,
+                    "failed",
+                    failedUpdate.Response.Id,
+                    failedUpdate.Response.Status?.ToString(),
+                    failedUpdate.Response.Error?.Code.ToString(),
+                    failedUpdate.Response.Error?.Message,
+                    failedUpdate.Response.IncompleteStatusDetails?.Reason?.ToString());
                 throw new ChatBackendUnavailableException(
                     BuildStreamingTerminalFailureMessage(failedUpdate.Response, "failed"),
                     errorCode: "stream_response_failed");
             }
             else if (update is StreamingResponseIncompleteUpdate incompleteUpdate)
             {
+                LogStreamingResponseTerminalUpdate(
+                    _Logger,
+                    "incomplete",
+                    incompleteUpdate.Response.Id,
+                    incompleteUpdate.Response.Status?.ToString(),
+                    incompleteUpdate.Response.Error?.Code.ToString(),
+                    incompleteUpdate.Response.Error?.Message,
+                    incompleteUpdate.Response.IncompleteStatusDetails?.Reason?.ToString());
                 throw new ChatBackendUnavailableException(
                     BuildStreamingTerminalFailureMessage(incompleteUpdate.Response, "incomplete"),
                     errorCode: "stream_response_incomplete");
@@ -674,6 +695,27 @@ public partial class AIChatService : IChatCompletionService
 
     [LoggerMessage(Level = LogLevel.Information, Message = "AI contextual search performed for prompt enrichment")]
     private static partial void LogContextualSearchPerformed(ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Streaming response error update received: responseId={ResponseId} code={Code} message={Message}")]
+    private static partial void LogStreamingResponseErrorUpdate(
+        ILogger logger,
+        string? responseId,
+        string code,
+        string message);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Streaming response terminal update: updateType={UpdateType} responseId={ResponseId} status={Status} errorCode={ErrorCode} errorMessage={ErrorMessage} incompleteReason={IncompleteReason}")]
+    private static partial void LogStreamingResponseTerminalUpdate(
+        ILogger logger,
+        string updateType,
+        string? responseId,
+        string? status,
+        string? errorCode,
+        string? errorMessage,
+        string? incompleteReason);
 
     /// <summary>
     /// Returns <c>true</c> when the API error indicates the conversation context window was exceeded.

--- a/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
@@ -194,6 +194,7 @@ public partial class AIChatService : IChatCompletionService
         string? currentLegResponseId = null;
         var textPartsWithDelta = new HashSet<string>(StringComparer.Ordinal);
         var refusalPartsWithDelta = new HashSet<string>(StringComparer.Ordinal);
+        var streamUpdateTypes = new List<string>(capacity: 64);
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         List<FunctionCallResponseItem>? pendingFunctionCalls = null;
 
@@ -202,6 +203,9 @@ public partial class AIChatService : IChatCompletionService
         // separate helper that puts try/catch only around MoveNextAsync.
         await foreach (var update in RethrowContextLengthErrors(streamingUpdates, responseOptions.PreviousResponseId, cancellationToken))
         {
+            var updateType = update.GetType().Name;
+            streamUpdateTypes.Add(updateType);
+
             if (update is StreamingResponseCreatedUpdate created)
             {
                 // Emit the response ID early so the controller can record ownership
@@ -254,7 +258,8 @@ public partial class AIChatService : IChatCompletionService
                     _Logger,
                     currentLegResponseId,
                     errorUpdate.Code ?? "unknown",
-                    errorUpdate.Message ?? "no message provided");
+                    errorUpdate.Message ?? "no message provided",
+                    BuildRecentUpdateSequence(streamUpdateTypes));
                 throw new ChatBackendUnavailableException(
                     $"Streaming response error: {errorUpdate.Code ?? "unknown"} - {errorUpdate.Message ?? "no message provided"}",
                     errorCode: "stream_response_error");
@@ -268,7 +273,8 @@ public partial class AIChatService : IChatCompletionService
                     failedUpdate.Response.Status?.ToString(),
                     failedUpdate.Response.Error?.Code.ToString(),
                     failedUpdate.Response.Error?.Message,
-                    failedUpdate.Response.IncompleteStatusDetails?.Reason?.ToString());
+                    failedUpdate.Response.IncompleteStatusDetails?.Reason?.ToString(),
+                    BuildRecentUpdateSequence(streamUpdateTypes));
                 throw new ChatBackendUnavailableException(
                     BuildStreamingTerminalFailureMessage(failedUpdate.Response, "failed"),
                     errorCode: "stream_response_failed");
@@ -282,7 +288,8 @@ public partial class AIChatService : IChatCompletionService
                     incompleteUpdate.Response.Status?.ToString(),
                     incompleteUpdate.Response.Error?.Code.ToString(),
                     incompleteUpdate.Response.Error?.Message,
-                    incompleteUpdate.Response.IncompleteStatusDetails?.Reason?.ToString());
+                    incompleteUpdate.Response.IncompleteStatusDetails?.Reason?.ToString(),
+                    BuildRecentUpdateSequence(streamUpdateTypes));
                 throw new ChatBackendUnavailableException(
                     BuildStreamingTerminalFailureMessage(incompleteUpdate.Response, "incomplete"),
                     errorCode: "stream_response_incomplete");
@@ -676,6 +683,15 @@ public partial class AIChatService : IChatCompletionService
 
         return $"Streaming response ended with status '{terminalStatus}'.";
     }
+
+    private static string BuildRecentUpdateSequence(List<string> streamUpdateTypes)
+    {
+        const int MaxUpdatesToInclude = 40;
+        int count = streamUpdateTypes.Count;
+        if (count <= MaxUpdatesToInclude)
+            return string.Join(" -> ", streamUpdateTypes);
+        return $"... -> {string.Join(" -> ", streamUpdateTypes.Skip(count - MaxUpdatesToInclude))}";
+    }
 #pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     [LoggerMessage(Level = LogLevel.Information, Message = "AI tool call invoked: tool={ToolName} iteration={Iteration} user={EndUserId}")]
@@ -698,16 +714,17 @@ public partial class AIChatService : IChatCompletionService
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Streaming response error update received: responseId={ResponseId} code={Code} message={Message}")]
+        Message = "Streaming response error update received: responseId={ResponseId} code={Code} message={Message} updateSequence={UpdateSequence}")]
     private static partial void LogStreamingResponseErrorUpdate(
         ILogger logger,
         string? responseId,
         string code,
-        string message);
+        string message,
+        string updateSequence);
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Streaming response terminal update: updateType={UpdateType} responseId={ResponseId} status={Status} errorCode={ErrorCode} errorMessage={ErrorMessage} incompleteReason={IncompleteReason}")]
+        Message = "Streaming response terminal update: updateType={UpdateType} responseId={ResponseId} status={Status} errorCode={ErrorCode} errorMessage={ErrorMessage} incompleteReason={IncompleteReason} updateSequence={UpdateSequence}")]
     private static partial void LogStreamingResponseTerminalUpdate(
         ILogger logger,
         string updateType,
@@ -715,7 +732,8 @@ public partial class AIChatService : IChatCompletionService
         string? status,
         string? errorCode,
         string? errorMessage,
-        string? incompleteReason);
+        string? incompleteReason,
+        string updateSequence);
 
     /// <summary>
     /// Returns <c>true</c> when the API error indicates the conversation context window was exceeded.

--- a/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
@@ -251,17 +251,20 @@ public partial class AIChatService : IChatCompletionService
             else if (update is StreamingResponseErrorUpdate errorUpdate)
             {
                 throw new ChatBackendUnavailableException(
-                    $"Streaming response error: {errorUpdate.Code ?? "unknown"} - {errorUpdate.Message ?? "no message provided"}");
+                    $"Streaming response error: {errorUpdate.Code ?? "unknown"} - {errorUpdate.Message ?? "no message provided"}",
+                    errorCode: "stream_response_error");
             }
             else if (update is StreamingResponseFailedUpdate failedUpdate)
             {
                 throw new ChatBackendUnavailableException(
-                    BuildStreamingTerminalFailureMessage(failedUpdate.Response, "failed"));
+                    BuildStreamingTerminalFailureMessage(failedUpdate.Response, "failed"),
+                    errorCode: "stream_response_failed");
             }
             else if (update is StreamingResponseIncompleteUpdate incompleteUpdate)
             {
                 throw new ChatBackendUnavailableException(
-                    BuildStreamingTerminalFailureMessage(incompleteUpdate.Response, "incomplete"));
+                    BuildStreamingTerminalFailureMessage(incompleteUpdate.Response, "incomplete"),
+                    errorCode: "stream_response_incomplete");
             }
             // StreamingResponseCompletedUpdate: ResponseId already emitted above — no-op.
         }

--- a/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/AIChatService.cs
@@ -205,7 +205,8 @@ public partial class AIChatService : IChatCompletionService
         {
             var updateType = update.GetType().Name;
             streamUpdateTypes.Add(updateType);
-
+            if (streamUpdateTypes.Count > 40)
+                streamUpdateTypes.RemoveAt(0);
             if (update is StreamingResponseCreatedUpdate created)
             {
                 // Emit the response ID early so the controller can record ownership

--- a/EssentialCSharp.Chat.Shared/Services/ChatBackendUnavailableException.cs
+++ b/EssentialCSharp.Chat.Shared/Services/ChatBackendUnavailableException.cs
@@ -1,4 +1,15 @@
 namespace EssentialCSharp.Chat.Common.Services;
 
-public class ChatBackendUnavailableException(string message, Exception? innerException = null)
-    : Exception(message, innerException);
+public class ChatBackendUnavailableException : Exception
+{
+    public string ErrorCode { get; }
+
+    public ChatBackendUnavailableException(
+        string message,
+        string errorCode = "chat_unavailable",
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        ErrorCode = string.IsNullOrWhiteSpace(errorCode) ? "chat_unavailable" : errorCode;
+    }
+}

--- a/EssentialCSharp.Chat.Shared/Services/LocalChatService.cs
+++ b/EssentialCSharp.Chat.Shared/Services/LocalChatService.cs
@@ -71,11 +71,11 @@ public partial class LocalChatService : IChatCompletionService, IDisposable
         }
         catch (HttpRequestException ex)
         {
-            throw new ChatBackendUnavailableException("Local AI backend is unavailable.", ex);
+            throw new ChatBackendUnavailableException("Local AI backend is unavailable.", innerException: ex);
         }
         catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
-            throw new ChatBackendUnavailableException("Local AI backend timed out.", ex);
+            throw new ChatBackendUnavailableException("Local AI backend timed out.", innerException: ex);
         }
 
         using (response)
@@ -87,15 +87,15 @@ public partial class LocalChatService : IChatCompletionService, IDisposable
             }
             catch (HttpRequestException ex)
             {
-                throw new ChatBackendUnavailableException("Local AI backend is unavailable while reading response.", ex);
+                throw new ChatBackendUnavailableException("Local AI backend is unavailable while reading response.", innerException: ex);
             }
             catch (IOException ex)
             {
-                throw new ChatBackendUnavailableException("Local AI backend connection closed while reading response.", ex);
+                throw new ChatBackendUnavailableException("Local AI backend connection closed while reading response.", innerException: ex);
             }
             catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
             {
-                throw new ChatBackendUnavailableException("Local AI backend timed out while reading response.", ex);
+                throw new ChatBackendUnavailableException("Local AI backend timed out while reading response.", innerException: ex);
             }
 
             if (!response.IsSuccessStatusCode)
@@ -117,7 +117,7 @@ public partial class LocalChatService : IChatCompletionService, IDisposable
             }
             catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException || ex is NotSupportedException)
             {
-                throw new ChatBackendUnavailableException("Local AI backend returned an invalid response.", ex);
+                throw new ChatBackendUnavailableException("Local AI backend returned an invalid response.", innerException: ex);
             }
         }
     }

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -278,14 +278,14 @@ public partial class ChatController : ControllerBase
             LogChatStreamErrorBeforeResponseStarted(_Logger, ex, User.Identity?.Name);
             Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             Response.ContentType = "application/json";
-            await Response.WriteAsJsonAsync(new { error = ex.Message, errorCode = ex.ErrorCode }, cancellationToken);
+            await Response.WriteAsJsonAsync(new { error = "Chat service unavailable", errorCode = ex.ErrorCode }, cancellationToken);
         }
         catch (ChatBackendUnavailableException ex)
         {
             LogChatStreamErrorMidStream(_Logger, ex, User.Identity?.Name);
             try
             {
-                var eventData = JsonSerializer.Serialize(new { type = "error", message = ex.Message, errorCode = ex.ErrorCode });
+                var eventData = JsonSerializer.Serialize(new { type = "error", message = "Chat service unavailable", errorCode = ex.ErrorCode });
                 await Response.WriteAsync($"data: {eventData}\n\n", CancellationToken.None);
                 await Response.Body.FlushAsync(CancellationToken.None);
             }

--- a/EssentialCSharp.Web/Controllers/ChatController.cs
+++ b/EssentialCSharp.Web/Controllers/ChatController.cs
@@ -278,14 +278,15 @@ public partial class ChatController : ControllerBase
             LogChatStreamErrorBeforeResponseStarted(_Logger, ex, User.Identity?.Name);
             Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             Response.ContentType = "application/json";
-            await Response.WriteAsJsonAsync(new { error = "Chat service unavailable", errorCode = "chat_unavailable" }, cancellationToken);
+            await Response.WriteAsJsonAsync(new { error = ex.Message, errorCode = ex.ErrorCode }, cancellationToken);
         }
         catch (ChatBackendUnavailableException ex)
         {
             LogChatStreamErrorMidStream(_Logger, ex, User.Identity?.Name);
             try
             {
-                await Response.WriteAsync("data: {\"type\":\"error\",\"message\":\"Chat service unavailable\",\"errorCode\":\"chat_unavailable\"}\n\n", CancellationToken.None);
+                var eventData = JsonSerializer.Serialize(new { type = "error", message = ex.Message, errorCode = ex.ErrorCode });
+                await Response.WriteAsync($"data: {eventData}\n\n", CancellationToken.None);
                 await Response.Body.FlushAsync(CancellationToken.None);
             }
             catch (Exception writeException) when (writeException is IOException or OperationCanceledException or ObjectDisposedException)


### PR DESCRIPTION
## Description

This pull request improves error handling and observability for AI chat streaming responses, focusing on better diagnostics and structured error reporting. The main changes include enhanced logging for streaming failures, more detailed error codes in exceptions, and improved propagation of error information to clients.

**Enhanced error logging and diagnostics:**

* Added tracking of streaming update types and new logging methods (`LogStreamingResponseErrorUpdate`, `LogStreamingResponseTerminalUpdate`) to capture detailed sequences of events leading to streaming errors or failures, aiding in troubleshooting and monitoring. [[1]](diffhunk://#diff-2e3a8204c3630d2aad08cd1583dd37bb97b89bebdb390cd9684fbdd60615f710R197) [[2]](diffhunk://#diff-2e3a8204c3630d2aad08cd1583dd37bb97b89bebdb390cd9684fbdd60615f710R206-R208) [[3]](diffhunk://#diff-2e3a8204c3630d2aad08cd1583dd37bb97b89bebdb390cd9684fbdd60615f710R257-R295) [[4]](diffhunk://#diff-2e3a8204c3630d2aad08cd1583dd37bb97b89bebdb390cd9684fbdd60615f710R686-R694) [[5]](diffhunk://#diff-2e3a8204c3630d2aad08cd1583dd37bb97b89bebdb390cd9684fbdd60615f710R715-R737)

**Error handling improvements:**

* Updated `ChatBackendUnavailableException` to include an `ErrorCode` property, allowing more granular identification of error conditions. The exception now defaults to `"chat_unavailable"` but can be set to more specific codes for different streaming failures.
* Updated all usages of `ChatBackendUnavailableException` in `LocalChatService` to consistently use the new `innerException` parameter name for clarity. [[1]](diffhunk://#diff-ef20d7ac4a2f9ca852c501655e3ce4aa3a0e256e06eec015b54456687c2743fbL74-R78) [[2]](diffhunk://#diff-ef20d7ac4a2f9ca852c501655e3ce4aa3a0e256e06eec015b54456687c2743fbL90-R98) [[3]](diffhunk://#diff-ef20d7ac4a2f9ca852c501655e3ce4aa3a0e256e06eec015b54456687c2743fbL120-R120)

**Client error propagation:**

* Modified `ChatController` to propagate the specific `ErrorCode` from `ChatBackendUnavailableException` in both standard and streaming error responses, ensuring clients receive accurate error details.

### Ensure that your pull request has followed all the steps below:
- [ ] Code compilation
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
