### PR TITLE
feat: improve cookie consent compliance

### DIFF
--- a/EssentialCSharp.Web/Controllers/HomeController.cs
+++ b/EssentialCSharp.Web/Controllers/HomeController.cs
@@ -56,6 +56,13 @@ public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment 
         return View();
     }
 
+    [Route("/cookie-policy", Name = "CookiePolicy")]
+    public IActionResult CookiePolicy()
+    {
+        ViewBag.PageTitle = "Cookie Policy";
+        return View();
+    }
+
     [Route("/Announcements", Name = "Announcements")]
     public IActionResult Announcements()
     {

--- a/EssentialCSharp.Web/Views/Home/CookiePolicy.cshtml
+++ b/EssentialCSharp.Web/Views/Home/CookiePolicy.cshtml
@@ -1,0 +1,131 @@
+@{
+    ViewData["Title"] = "Cookie Policy";
+}
+
+<div class="px-3">
+    <h1>@ViewData["Title"]</h1>
+    <hr class="divider-light-blue" />
+
+    <p>
+        This page explains how Essential C# uses cookies and similar browser storage technologies. We use
+        essential cookies required for security and sign-in, and optional analytics cookies only after you
+        grant analytics consent from the cookie banner or the <button type="button" class="btn btn-link p-0 align-baseline" onclick="openConsentPreferences()">Cookie Preferences</button> link.
+    </p>
+
+    <p>
+        We do not use advertising or personalization cookies on this site.
+    </p>
+
+    <h2>How to manage your consent</h2>
+    <p>
+        You can accept, reject, or withdraw analytics consent at any time from the footer's Cookie Preferences link.
+        Withdrawing consent also clears the analytics cookies we control from your browser.
+    </p>
+
+    <h2>Cookies we use</h2>
+
+    <div class="table-responsive">
+        <table class="table table-striped align-middle">
+            <thead>
+                <tr>
+                    <th scope="col">Cookie / Storage Key</th>
+                    <th scope="col">Category</th>
+                    <th scope="col">Provider</th>
+                    <th scope="col">Purpose</th>
+                    <th scope="col">Typical duration</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>essential-csharp-consent</code></td>
+                    <td>Essential</td>
+                    <td>Essential C#</td>
+                    <td>Stores your consent choices and the consent version so we know whether to show the banner again.</td>
+                    <td>365 days</td>
+                </tr>
+                <tr>
+                    <td><code>.AspNetCore.Identity.Application</code></td>
+                    <td>Essential</td>
+                    <td>Essential C# / ASP.NET Core Identity</td>
+                    <td>Keeps signed-in users authenticated while they use the site.</td>
+                    <td>Up to 60 minutes of inactivity, with sliding renewal while active</td>
+                </tr>
+                <tr>
+                    <td><code>.AspNetCore.Antiforgery.*</code></td>
+                    <td>Essential</td>
+                    <td>Essential C# / ASP.NET Core</td>
+                    <td>Protects forms and authenticated requests against cross-site request forgery attacks.</td>
+                    <td>Session or framework-managed</td>
+                </tr>
+                <tr>
+                    <td><code>_ga</code>, <code>_ga_*</code>, <code>_gid</code>, <code>_gat</code></td>
+                    <td>Analytics</td>
+                    <td>Google Analytics</td>
+                    <td>Measures page usage, sessions, and engagement after analytics consent is granted.</td>
+                    <td>Varies by cookie; commonly from 1 minute to 2 years</td>
+                </tr>
+                <tr>
+                    <td><code>_clck</code>, <code>_clsk</code>, <code>CLID</code>, <code>ANONCHK</code>, <code>MR</code>, <code>MUID</code>, <code>SM</code></td>
+                    <td>Analytics</td>
+                    <td>Microsoft Clarity</td>
+                    <td>Helps us understand aggregated interaction patterns such as clicks, scrolling, and session behavior after analytics consent is granted.</td>
+                    <td>Varies by cookie; typically session to 1 year</td>
+                </tr>
+                <tr>
+                    <td><code>ai_user</code>, <code>ai_session</code></td>
+                    <td>Analytics</td>
+                    <td>Azure Application Insights</td>
+                    <td>Measures client-side telemetry and page activity after analytics consent is granted.</td>
+                    <td>Typically session to 1 year</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>Other browser storage we use</h2>
+
+    <div class="table-responsive">
+        <table class="table table-striped align-middle">
+            <thead>
+                <tr>
+                    <th scope="col">Storage Key</th>
+                    <th scope="col">Storage Type</th>
+                    <th scope="col">Purpose</th>
+                    <th scope="col">Typical duration</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>aiChatHistory</code></td>
+                    <td>localStorage</td>
+                    <td>Stores recent authenticated AI chat messages in your browser so the chat widget can restore the latest conversation state.</td>
+                    <td>Up to 2 hours unless you clear it sooner</td>
+                </tr>
+                <tr>
+                    <td><code>aiChatLastResponseId</code></td>
+                    <td>sessionStorage</td>
+                    <td>Stores the last AI response identifier for the current tab to continue the active chat safely.</td>
+                    <td>Current browser tab session</td>
+                </tr>
+                <tr>
+                    <td><code>sidebarShown</code></td>
+                    <td>localStorage</td>
+                    <td>Remembers whether the table-of-contents sidebar is shown or hidden on non-identity pages.</td>
+                    <td>Until you clear browser storage</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>Third-party services</h2>
+    <p>
+        When you consent to analytics, the site may load Google Analytics, Microsoft Clarity, and Azure Application Insights.
+        These providers may process technical data such as IP-derived region information, page URLs, browser metadata, and
+        usage events according to their own privacy documentation.
+    </p>
+
+    <p>
+        For broader information about how personal data is handled, please see the
+        <a href="https://intellitect.com/about/privacy-policy/" target="_blank" rel="noreferrer noopener">IntelliTect Privacy Policy</a>.
+    </p>
+</div>

--- a/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
+++ b/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
@@ -42,11 +42,6 @@
     <link rel="stylesheet" href="~/css/chat-widget.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/code-runner.css" asp-append-version="true" />
     <link rel="stylesheet" href="/lib/docsearch/style.css" />
-    @*Font Family*@
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900&display=auto" rel="stylesheet">
-    @*End Font Family*@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -56,6 +51,7 @@
     <meta name="theme-color" content="#ffffff">
     <!-- Cookie Consent Manager - Load before analytics -->
     <script src="~/js/consent-manager.js" asp-append-version="true"></script>
+    <script src="~/js/clarity-manager.js" asp-append-version="true"></script>
     <script src="~/js/appinsights-manager.js" asp-append-version="true"></script>
     @{
         string? authUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -66,16 +62,6 @@
         // user GUID to third-party scripts that enumerate window properties.
         <meta name="ecs-auth-user-id" content="@authUserId" />
     }
-    
-    <!-- Microsoft Clarity - Will be activated based on consent -->
-    <script type="text/javascript">
-        (function (c, l, a, r, i, t, y) {
-            c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
-            t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
-            y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
-        })(window, document, "clarity", "script", "g4keetzd2o");
-    </script>
-    
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css">
     <!-- Google tag (gtag.js) - Consent defaults MUST be set before gtag.js loads (Google Consent Mode v2 requirement) -->
     <script>
@@ -83,12 +69,8 @@
         function gtag(){dataLayer.push(arguments);}
         gtag('consent', 'default', {
             analytics_storage: 'denied',
-            ad_storage: 'denied',
-            ad_user_data: 'denied',
-            ad_personalization: 'denied',
             functionality_storage: 'granted',
             security_storage: 'granted',
-            personalization_storage: 'denied',
             wait_for_update: 500  // ms to hold GA pings while consent banner loads
         });
         gtag('js', new Date());
@@ -175,6 +157,9 @@
             </div>
             <div class="col-12 col-md-auto align-self-end p-2">
                 <a target="_blank" rel="noreferrer noopener" href="https://intellitect.com/about/privacy-policy/">Privacy</a>
+            </div>
+            <div class="col-12 col-md-auto align-self-end p-2">
+                <a asp-route="CookiePolicy">Cookie Policy</a>
             </div>
             <div class="col-12 col-md-auto align-self-end p-2">
                 <button type="button" class="btn btn-link p-0 align-baseline" onclick="openConsentPreferences()">Cookie Preferences</button>

--- a/EssentialCSharp.Web/wwwroot/css/chat-widget.css
+++ b/EssentialCSharp.Web/wwwroot/css/chat-widget.css
@@ -34,7 +34,7 @@
     bottom: 24px;
     right: 24px;
     z-index: 1050;
-    font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: system-ui, -apple-system, "Segoe UI", BlinkMacSystemFont, sans-serif;
 }
 
 /* Responsive positioning to avoid navigation conflicts */

--- a/EssentialCSharp.Web/wwwroot/css/styles.css
+++ b/EssentialCSharp.Web/wwwroot/css/styles.css
@@ -20,7 +20,7 @@ html {
 }
 
 body {
-  font-family: "Roboto", Arial, Helvetica, sans-serif;
+  font-family: system-ui, -apple-system, "Segoe UI", Arial, Helvetica, sans-serif;
 }
 
 h1,
@@ -197,7 +197,7 @@ a:hover {
 }
 
 .DocSearch-Container {
-  font-family: "Roboto", Arial, Helvetica, sans-serif !important;
+  font-family: system-ui, -apple-system, "Segoe UI", Arial, Helvetica, sans-serif !important;
 }
 
 /* Nav Menu Styles */

--- a/EssentialCSharp.Web/wwwroot/js/clarity-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/clarity-manager.js
@@ -1,0 +1,98 @@
+/**
+ * Microsoft Clarity loader for Essential C#.
+ * Loads only after analytics consent is granted and updates consent state when available.
+ */
+(function () {
+    const CONSENT_EVENT = "ecs:consent-changed";
+    const CLARITY_PROJECT_ID = "g4keetzd2o";
+    const SDK_URL = `https://www.clarity.ms/tag/${CLARITY_PROJECT_ID}`;
+
+    let clarityLoadPromise = null;
+
+    function hasAnalyticsConsent() {
+        if (window.consentManager && typeof window.consentManager.hasAnalyticsConsent === "function") {
+            return window.consentManager.hasAnalyticsConsent();
+        }
+
+        const state = typeof window.getEcsConsentState === "function" ? window.getEcsConsentState() : null;
+        return !!(state && state.analytics_storage === "granted");
+    }
+
+    function ensureClarityQueue() {
+        if (typeof window.clarity !== "function") {
+            window.clarity = function () {
+                (window.clarity.q = window.clarity.q || []).push(arguments);
+            };
+        }
+    }
+
+    function ensureSdkLoaded() {
+        ensureClarityQueue();
+
+        if (document.querySelector(`script[src="${SDK_URL}"]`)) {
+            return clarityLoadPromise || Promise.resolve();
+        }
+
+        if (clarityLoadPromise) {
+            return clarityLoadPromise;
+        }
+
+        clarityLoadPromise = new Promise((resolve, reject) => {
+            const script = document.createElement("script");
+            script.src = SDK_URL;
+            script.async = true;
+            script.onload = () => resolve();
+            script.onerror = () => {
+                clarityLoadPromise = null;
+                script.remove();
+                reject(new Error("Failed to load Microsoft Clarity."));
+            };
+            document.head.appendChild(script);
+        });
+
+        return clarityLoadPromise;
+    }
+
+    function updateConsent() {
+        if (typeof window.clarity === "function") {
+            try {
+                window.clarity("consentv2", {
+                    analytics_storage: hasAnalyticsConsent() ? "granted" : "denied"
+                });
+            } catch (error) {
+                console.warn("Failed to update Clarity consent:", error);
+            }
+        }
+    }
+
+    function syncConsentState() {
+        if (!hasAnalyticsConsent()) {
+            updateConsent();
+            return;
+        }
+
+        ensureSdkLoaded()
+            .then(() => {
+                if (!hasAnalyticsConsent()) {
+                    updateConsent();
+                    return;
+                }
+
+                updateConsent();
+            })
+            .catch((error) => {
+                console.warn("Microsoft Clarity initialization failed:", error);
+            });
+    }
+
+    function init() {
+        window.addEventListener(CONSENT_EVENT, syncConsentState);
+        syncConsentState();
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init, { once: true });
+    } else {
+        init();
+    }
+})();

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -8,15 +8,11 @@ class ConsentManager {
     constructor() {
         this.COOKIE_NAME = 'essential-csharp-consent';
         this.COOKIE_DURATION = 365; // days
-        this.CONSENT_VERSION = '2'; // Bump this to re-prompt all users when consent terms change
+        this.CONSENT_VERSION = '3'; // Bump this to re-prompt all users when consent terms change
         this.consentState = {
             analytics_storage: 'denied',
-            ad_storage: 'denied',
-            ad_user_data: 'denied',
-            ad_personalization: 'denied',
             functionality_storage: 'granted', // Always granted for essential functionality
-            security_storage: 'granted', // Always granted for security
-            personalization_storage: 'denied'
+            security_storage: 'granted' // Always granted for security
         };
         
         this.init();
@@ -28,8 +24,6 @@ class ConsentManager {
         // Load saved consent preferences (signals GA if already consented)
         this.loadConsentPreferences();
 
-        // Always send Clarity the current consent state (denied by default for new visitors).
-        // Clarity's polyfill queues this call and delivers it when the script loads.
         this.updateClarityConsent();
         
         // Show banner if no valid consent stored
@@ -62,8 +56,7 @@ class ConsentManager {
                 // Validate and only apply known consent properties for security.
                 // Exclude functionality_storage and security_storage — always essential, never user-overrideable.
                 const validConsentKeys = [
-                    'analytics_storage', 'ad_storage', 'ad_user_data', 
-                    'ad_personalization', 'personalization_storage'
+                    'analytics_storage'
                 ];
                 
                 const validatedPreferences = {};
@@ -110,7 +103,7 @@ class ConsentManager {
             <div class="consent-banner-content">
                 <div class="consent-banner-text">
                     <h3>Cookie Preferences</h3>
-                    <p>We use cookies to improve your experience and analyze website usage. See our <a href="https://intellitect.com/about/privacy-policy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a> for details.</p>
+                    <p>We use essential cookies to keep the site secure and optional analytics cookies to understand site usage. See our <a href="/cookie-policy">Cookie Policy</a> and <a href="https://intellitect.com/about/privacy-policy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a> for details.</p>
                 </div>
                 <div class="consent-banner-actions">
                     <button id="consent-reject-all" class="btn btn-outline-secondary me-2">Reject All</button>
@@ -135,22 +128,13 @@ class ConsentManager {
                         <span class="consent-slider"></span>
                         <div class="consent-info">
                             <strong>Analytics Cookies</strong>
-                            <p>Help us understand how you use our site to improve your experience.</p>
-                        </div>
-                    </label>
-                </div>
-                <div class="consent-category">
-                    <label class="consent-switch">
-                        <input type="checkbox" id="consent-advertising">
-                        <span class="consent-slider"></span>
-                        <div class="consent-info">
-                            <strong>Google Signals</strong>
-                            <p>Allows Google to associate your visit with your Google account for analytics modeling and cross-site measurement. No advertisements are served on this site, but Google may use this data across its services.</p>
+                            <p>Help us understand how you use the site through Google Analytics, Microsoft Clarity, and Azure Application Insights. We do not use advertising or personalization cookies.</p>
                         </div>
                     </label>
                 </div>
                 <div class="consent-actions">
                     <button id="consent-save-preferences" class="btn btn-primary">Save Preferences</button>
+                    <button id="consent-withdraw-consent" class="btn btn-outline-secondary ms-2" type="button">Withdraw Consent</button>
                 </div>
             </div>
         `;
@@ -177,6 +161,10 @@ class ConsentManager {
         banner.querySelector('#consent-save-preferences').addEventListener('click', () => {
             this.saveCustomPreferences();
         });
+
+        banner.querySelector('#consent-withdraw-consent').addEventListener('click', () => {
+            this.revokeAllConsent();
+        });
     }
 
     showCustomizeOptions() {
@@ -187,19 +175,13 @@ class ConsentManager {
             // Load current preferences into checkboxes
             document.getElementById('consent-analytics').checked = 
                 this.consentState.analytics_storage === 'granted';
-            document.getElementById('consent-advertising').checked = 
-                this.consentState.ad_storage === 'granted';
         }
     }
 
     acceptAllConsent() {
         this.consentState = {
             ...this.consentState,
-            analytics_storage: 'granted',
-            ad_storage: 'granted',
-            ad_user_data: 'granted',
-            ad_personalization: 'granted',
-            personalization_storage: 'granted'
+            analytics_storage: 'granted'
         };
         
         this.saveConsentAndClose();
@@ -208,11 +190,7 @@ class ConsentManager {
     rejectAllConsent() {
         this.consentState = {
             ...this.consentState,
-            analytics_storage: 'denied',
-            ad_storage: 'denied',
-            ad_user_data: 'denied',
-            ad_personalization: 'denied',
-            personalization_storage: 'denied'
+            analytics_storage: 'denied'
         };
         
         this.saveConsentAndClose();
@@ -220,15 +198,10 @@ class ConsentManager {
 
     saveCustomPreferences() {
         const analyticsChecked = document.getElementById('consent-analytics').checked;
-        const advertisingChecked = document.getElementById('consent-advertising').checked;
         
         this.consentState = {
             ...this.consentState,
-            analytics_storage: analyticsChecked ? 'granted' : 'denied',
-            ad_storage: advertisingChecked ? 'granted' : 'denied',
-            ad_user_data: advertisingChecked ? 'granted' : 'denied',
-            ad_personalization: advertisingChecked ? 'granted' : 'denied',
-            personalization_storage: advertisingChecked ? 'granted' : 'denied'
+            analytics_storage: analyticsChecked ? 'granted' : 'denied'
         };
         
         this.saveConsentAndClose();
@@ -271,7 +244,6 @@ class ConsentManager {
         if (window.clarity) {
             try {
                 window.clarity('consentv2', {
-                    ad_storage: this.consentState.ad_storage,
                     analytics_storage: this.consentState.analytics_storage
                 });
             } catch (error) {
@@ -434,7 +406,7 @@ class ConsentManager {
     }
 
     hasAdvertisingConsent() {
-        return this.consentState.ad_storage === 'granted';
+        return false;
     }
 
     notifyConsentChanged() {


### PR DESCRIPTION
This tightens the site's cookie-consent behavior so it matches the simpler legal posture we actually want: essential cookies by default, optional analytics only after consent, and no ad or personalization consent requests when the site does not serve ads.

It adds a dedicated cookie policy page, updates the consent banner copy and controls, and removes Google Signals-style ad consent fields from the consent state entirely. Clarity is now loaded only after analytics consent is granted, matching the existing deferred Application Insights behavior, and the banner now exposes an explicit withdraw-consent action. The new policy page also documents browser storage that is not cookie-based, including chat history and sidebar preferences.

A few implementation notes for review:
- The font change removes the Google Fonts dependency and switches to system fonts to avoid the external font request entirely.
- `CONSENT_VERSION` was bumped to `3` so existing visitors are re-prompted with the updated consent model.
- The web project builds cleanly. The full solution restore/build is still blocked by pre-existing vulnerable test dependencies in `EssentialCSharp.Web.Tests`, which are unrelated to this PR.

## What changed
- add `/cookie-policy` and link it from the footer and banner
- remove ad/personalization consent fields from the Google consent model
- defer Microsoft Clarity script loading until analytics consent
- add a withdraw-consent action to the consent UI
- replace Google Fonts usage with system font fallbacks
- disclose `localStorage` and `sessionStorage` usage on the policy page