### PR TITLE
fix: set CodeQL C# build mode to none

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        build-mode: none
 
     - name: Set up .NET Core
       uses: actions/setup-dotnet@v5


### PR DESCRIPTION
## Why
CodeQL C# analysis was receiving an invalid build mode value (`undefined`), which caused database initialization to fail and the workflow to exit with code 1.

## What changed
Set `build-mode: none` explicitly in `.github/workflows/codeql.yml` for the `analyze-csharp` job's `github/codeql-action/init@v4` step.

## Notes
This makes the workflow deterministic for this repository and prevents fallback behavior caused by missing or invalid build-mode resolution.