### PR TITLE
fix(logging): route Information logs to Azure Monitor via OTel filter

### DIFF
--- a/EssentialCSharp.Web/appsettings.json
+++ b/EssentialCSharp.Web/appsettings.json
@@ -6,6 +6,14 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "OpenTelemetry": {
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Warning"
+      }
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
## Why

`appsettings.json` sets `Logging:LogLevel:Default` to `Warning` in production. Since .NET's logging filter pipeline applies before any provider (including the OpenTelemetry/Azure Monitor exporter) sees a log record, this meant every `Information`-level structured log call (logins, emails sent, cache activity, etc.) was being dropped before it could ever reach Azure Monitor - regardless of how the OTel/Azure Monitor exporter itself was configured.

## What changed

Added a provider-scoped `Logging:OpenTelemetry:LogLevel` section to `appsettings.json`, setting `Default` to `Information` (with `Microsoft`/`Microsoft.AspNetCore`/`System` still at `Warning` to avoid framework noise). This does not touch the global `Logging:LogLevel:Default` (still `Warning`), so console/other providers are unaffected - only what reaches the OpenTelemetry provider (and therefore Azure Monitor) is raised to `Information`.

This relies on `OpenTelemetryLoggerProvider` (from `OpenTelemetry.Extensions.Hosting`) declaring `[ProviderAlias("OpenTelemetry")]`, which is what makes `Logging:OpenTelemetry:LogLevel` a recognized, provider-specific override rather than a no-op. I verified this empirically by reflecting on the actual package assembly in a throwaway console app rather than assuming it from documentation.

## Trade-off to be aware of

This intentionally increases Application Insights/Log Analytics ingestion volume (and therefore cost), since Information-level logs across the app will now be exported. This was a deliberate choice to restore operational visibility (e.g. auth events, email sends) that was previously silently dropped in production.