### PR TITLE
perf: extract MCP token normalization into dedicated middleware

### DIFF
--- a/EssentialCSharp.Web/Middleware/McpTokenNormalizationMiddleware.cs
+++ b/EssentialCSharp.Web/Middleware/McpTokenNormalizationMiddleware.cs
@@ -1,0 +1,34 @@
+using System.Security.Claims;
+using EssentialCSharp.Web.Auth;
+using EssentialCSharp.Web.Services;
+
+namespace EssentialCSharp.Web.Middleware;
+
+/// <summary>
+/// Normalizes the <see cref="HttpContext.User"/> for MCP requests before rate limiting.
+/// Valid MCP bearer tokens resolve to an MCP user principal; missing or invalid tokens
+/// fall back to an anonymous principal so they bucket by IP rather than inheriting the
+/// site's cookie principal.
+/// </summary>
+public class McpTokenNormalizationMiddleware(RequestDelegate next)
+{
+    // Cached singleton — avoids allocating new ClaimsPrincipal/ClaimsIdentity per request
+    // for the common case of unauthenticated or non-bearer MCP requests.
+    private static readonly ClaimsPrincipal AnonymousPrincipal = new(new ClaimsIdentity());
+
+    public async Task InvokeAsync(HttpContext context, McpApiTokenService tokenService)
+    {
+        McpApiTokenService.ResolvedMcpApiToken? resolvedToken = null;
+        if (McpBearerAuthentication.TryGetRawToken(context.Request, out string? rawToken))
+        {
+            resolvedToken = await tokenService.ResolveValidTokenAsync(rawToken, context.RequestAborted);
+            McpBearerAuthentication.StoreResolution(context, resolvedToken);
+        }
+
+        context.User = resolvedToken is not null
+            ? McpBearerAuthentication.CreatePrincipal(resolvedToken.UserId)
+            : AnonymousPrincipal;
+
+        await next(context);
+    }
+}

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -563,28 +563,13 @@ public partial class Program
 
         app.UseAuthentication();
 
+        // /mcp uses a named non-default scheme. Normalize the principal before
+        // rate limiting so valid MCP requests partition by MCP user while
+        // missing/invalid bearer requests fall back to the anonymous/IP bucket
+        // instead of inheriting the site's cookie principal.
         app.UseWhen(
             context => context.Request.Path.StartsWithSegments("/mcp"),
-            branch => branch.Use(async (context, next) =>
-            {
-                // /mcp uses a named non-default scheme. Normalize the principal before
-                // rate limiting so valid MCP requests partition by MCP user while
-                // missing/invalid bearer requests fall back to the anonymous/IP bucket
-                // instead of inheriting the site's cookie principal.
-                McpApiTokenService.ResolvedMcpApiToken? resolvedToken = null;
-                if (McpBearerAuthentication.TryGetRawToken(context.Request, out string? rawToken))
-                {
-                    var tokenService = context.RequestServices.GetRequiredService<McpApiTokenService>();
-                    resolvedToken = await tokenService.ResolveValidTokenAsync(rawToken, context.RequestAborted);
-                    McpBearerAuthentication.StoreResolution(context, resolvedToken);
-                }
-
-                context.User = resolvedToken is not null
-                    ? McpBearerAuthentication.CreatePrincipal(resolvedToken.UserId)
-                    : new ClaimsPrincipal(new ClaimsIdentity());
-
-                await next(context);
-            }));
+            branch => branch.UseMiddleware<McpTokenNormalizationMiddleware>());
 
         app.UseRateLimiter();
 


### PR DESCRIPTION
## Why

A production memory profiler flagged that 93% of allocations traced back to `UseWhenExtensions.UseWhen` in the middleware pipeline. Investigation revealed two issues:

1. **Structural attribution:** `UseWhen` is registered before `UseRateLimiter`, `UseAuthorization`, and all page/controller handlers, so every request has it as a common ancestor in the async call stack. The 93% figure is expected given pipeline ordering, not a memory leak.

2. **Avoidable per-request allocations:** The inline `async (context, next) =>` lambda registered inside the second `UseWhen` allocated on every `/mcp` request:
   - A new async state machine heap object per invocation
   - `new ClaimsPrincipal(new ClaimsIdentity())` for every unauthenticated `/mcp` request (the anonymous fallback case)

## What changed

Extracted the inline lambda into `McpTokenNormalizationMiddleware`:

- **Cached `AnonymousPrincipal`** as a `private static readonly` field -- no per-request allocation for the unauthenticated case
- **Eliminated the display-class closure** that the inline lambda created
- **`McpApiTokenService` is now injected via `InvokeAsync`** parameter so the DI container manages its lifetime cleanly, removing the `GetRequiredService` call from inside the hot path
- Logic and ordering are otherwise identical: runs after `UseAuthentication`, before `UseRateLimiter`, only for `/mcp` paths