### PR TITLE
fix(consent): toggle customize panel and clear Clarity cookies on revoke

### DIFF
--- a/EssentialCSharp.Web/wwwroot/js/clarity-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/clarity-manager.js
@@ -53,6 +53,24 @@
         return clarityLoadPromise;
     }
 
+    function clearClarityCookies() {
+        const clarityCookies = ['_clck', '_clsk', 'CLID', 'ANONCHK', 'MR', 'MUID', 'SM'];
+        const expired = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
+        const secure = window.location.protocol === 'https:' ? ';Secure' : '';
+        const hostname = window.location.hostname;
+        const parts = hostname.split('.');
+        const domains = [hostname];
+        for (let i = 0; i < parts.length - 1; i++) {
+            domains.push('.' + parts.slice(i).join('.'));
+        }
+        clarityCookies.forEach(name => {
+            document.cookie = `${name}=;${expired};path=/${secure}`;
+            domains.forEach(domain => {
+                document.cookie = `${name}=;${expired};path=/;domain=${domain}${secure}`;
+            });
+        });
+    }
+
     function updateConsent() {
         if (typeof window.clarity === "function") {
             try {
@@ -68,6 +86,7 @@
     function syncConsentState() {
         if (!hasAnalyticsConsent()) {
             updateConsent();
+            clearClarityCookies();
             return;
         }
 

--- a/EssentialCSharp.Web/wwwroot/js/consent-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/consent-manager.js
@@ -170,6 +170,11 @@ class ConsentManager {
     showCustomizeOptions() {
         const details = document.getElementById('consent-details');
         if (details) {
+            const isExpanded = details.style.display !== 'none' && details.style.display !== '';
+            if (isExpanded) {
+                details.style.display = 'none';
+                return;
+            }
             details.style.display = 'block';
             
             // Load current preferences into checkboxes


### PR DESCRIPTION
## Summary

Two consent-system bugs found and fixed via Playwright testing against dev.essentialcsharp.com.

### Bug 1 — Customize panel doesn't collapse

**Problem:** Clicking the "Customize" button a second time always re-showed the details panel. There was no collapse/toggle behavior.

**Fix:** `showCustomizeOptions()` in `consent-manager.js` now checks whether `#consent-details` is already visible. If expanded, it sets `display = 'none'` and returns early. Otherwise it opens and pre-fills the checkboxes as before.

### Bug 2 — Microsoft Clarity cookies not cleared on Reject/Revoke

**Problem:** `clearTrackingCookies()` (which erases `_clck`, `_clsk`, `CLID`, etc.) was only called from `revokeAllConsent()` (the "Withdraw Consent" path). A normal "Reject All" click, or re-opening preferences and rejecting mid-session, sent the Clarity `consentv2` signal but never deleted the existing Clarity cookies from the browser.

**Fix:** Added `clearClarityCookies()` to `clarity-manager.js`. It mirrors the domain-iteration logic in `clearTrackingCookies()` but is scoped to the seven Clarity cookies. It is called from `syncConsentState()` whenever `hasAnalyticsConsent()` is false — covering Reject All, mid-session revoke, and the existing Withdraw path.

## Testing

Playwright tests (injecting patched scripts into live dev site) verified:

| Scenario | Result |
|---|---|
| Customize opens on 1st click | ✅ |
| Customize collapses on 2nd click | ✅ |
| Customize re-opens on 3rd click | ✅ |
| Analytics checkbox pre-filled on re-open | ✅ |
| Clarity cookies seeded before reject | ✅ |
| `_clck` cleared on Reject All | ✅ |
| `_clsk` cleared on Reject All | ✅ |
| `CLID` cleared on Reject All | ✅ |
| `_clck` cleared on mid-session revoke | ✅ |
| `_clsk` cleared on mid-session revoke | ✅ |
| `_clck` cleared on Withdraw | ✅ |
| `_clsk` cleared on Withdraw | ✅ |
| Clarity cookies preserved on Accept All | ✅ |