### PR TITLE
fix: correlate browser and server app insights

### DIFF
--- a/EssentialCSharp.Web/wwwroot/js/appinsights-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/appinsights-manager.js
@@ -5,6 +5,11 @@
 (function () {
     const SDK_URL = "https://js.monitor.azure.com/scripts/b/ai.3.gbl.min.js";
     const CONSENT_EVENT = "ecs:consent-changed";
+    const DistributedTracingModes = {
+        AI: 0,
+        AI_AND_W3C: 1,
+        W3C: 2
+    };
 
     let appInsights = null;
     let sdkLoadPromise = null;
@@ -13,6 +18,25 @@
     function getConnectionString() {
         const value = window.APPLICATIONINSIGHTS_CONNECTION_STRING;
         return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+    }
+
+    function getTryDotNetOrigin() {
+        const value = window.TRYDOTNET_ORIGIN;
+        return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+    }
+
+    function getCorrelationHeaderDomains() {
+        const domains = [window.location.hostname];
+        const tryDotNetOrigin = getTryDotNetOrigin();
+        if (tryDotNetOrigin) {
+            try {
+                domains.push(new URL(tryDotNetOrigin).hostname);
+            } catch (error) {
+                console.warn("Ignoring invalid TryDotNet origin for App Insights correlation:", error);
+            }
+        }
+
+        return Array.from(new Set(domains.filter(Boolean)));
     }
 
     function hasAnalyticsConsent() {
@@ -113,7 +137,11 @@
         const instance = new window.Microsoft.ApplicationInsights.ApplicationInsights({
             config: {
                 connectionString,
-                disableAjaxTracking: true, // avoid duplicate/debatable dependency telemetry from browser fetch/XHR
+                disableAjaxTracking: false,
+                disableFetchTracking: false,
+                distributedTracingMode: DistributedTracingModes.W3C,
+                correlationHeaderDomains: getCorrelationHeaderDomains(),
+                enableCorsCorrelation: true,
                 disableTelemetry: false
             }
         });

--- a/EssentialCSharp.Web/wwwroot/js/chat-module.js
+++ b/EssentialCSharp.Web/wwwroot/js/chat-module.js
@@ -12,6 +12,17 @@ const errorIconClassByType = {
     'connection-error': 'fas fa-plug'
 };
 
+function getTraceHeaders() {
+    const headers = {};
+    if (typeof window.ecsGetCorrelationContext === 'function') {
+        const traceparent = window.ecsGetCorrelationContext();
+        if (typeof traceparent === 'string' && traceparent.length > 0) {
+            headers.traceparent = traceparent;
+        }
+    }
+    return headers;
+}
+
 // hCaptcha integration — invisible widget renders once and is reused across messages.
 // When HCAPTCHA_SITE_KEY is null (dev / captcha not configured), all captcha calls are no-ops.
 const captchaSiteKey = window.HCAPTCHA_SITE_KEY || null;
@@ -338,6 +349,7 @@ export function useChatWidget() {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
+                    ...getTraceHeaders()
                 },
                 body: JSON.stringify(requestBody)
             });

--- a/EssentialCSharp.Web/wwwroot/js/trydotnet-module.js
+++ b/EssentialCSharp.Web/wwwroot/js/trydotnet-module.js
@@ -31,6 +31,15 @@ function getCorrelationContext() {
     return null;
 }
 
+function getTraceHeaders() {
+    const headers = {};
+    const correlationContext = getCorrelationContext();
+    if (typeof correlationContext === 'string' && correlationContext.length > 0) {
+        headers.traceparent = correlationContext;
+    }
+    return headers;
+}
+
 function trackTryEvent(name, properties = {}, measurements = {}) {
     const appInsights = getAppInsights();
     if (!appInsights || typeof appInsights.trackEvent !== 'function') {
@@ -244,6 +253,7 @@ export function useTryDotNet() {
             const res = await fetch(`${origin}/api/trydotnet.min.js`, {
                 method: 'HEAD',
                 mode: 'no-cors',
+                headers: getTraceHeaders(),
                 signal: controller.signal,
             });
             // mode: 'no-cors' gives an opaque response (status 0), which is fine
@@ -489,7 +499,9 @@ export function useTryDotNet() {
      * @returns {Promise<string>} The listing source code (extracted snippet)
      */
     async function fetchListingCode(chapter, listing) {
-        const response = await fetch(`/api/ListingSourceCode/chapter/${chapter}/listing/${listing}`);
+        const response = await fetch(`/api/ListingSourceCode/chapter/${chapter}/listing/${listing}`, {
+            headers: getTraceHeaders()
+        });
         if (!response.ok) {
             throw new Error(ERROR_MESSAGES.fetchFailed);
         }

--- a/EssentialCSharp.Web/wwwroot/js/trydotnet-module.js
+++ b/EssentialCSharp.Web/wwwroot/js/trydotnet-module.js
@@ -250,10 +250,9 @@ export function useTryDotNet() {
         try {
             // Check the actual script endpoint rather than the bare origin,
             // which may not have a handler and would return 404.
-            const res = await fetch(`${origin}/api/trydotnet.min.js`, {
+            await fetch(`${origin}/api/trydotnet.min.js`, {
                 method: 'HEAD',
                 mode: 'no-cors',
-                headers: getTraceHeaders(),
                 signal: controller.signal,
             });
             // mode: 'no-cors' gives an opaque response (status 0), which is fine


### PR DESCRIPTION
## Why

Application Insights was splitting browser-initiated flows from the ASP.NET Core backend, which made it difficult to inspect a single end-to-end trace for chat and TryDotNet interactions. This change aligns the browser and server telemetry on the same W3C trace id so Application Insights can show one correlated request flow.

## What changed

- re-enabled browser dependency tracking in the App Insights JS setup and configured it for W3C distributed tracing
- allowed correlation headers for the site host and the configured TryDotNet host so same-origin and TryDotNet requests can stay on the same trace
- added `traceparent` propagation on the chat stream request and listing source fetches
- kept the existing TryDotNet `correlationContext` bridge so TryDotNet session creation can continue to join the browser trace during the transition

## Notes for reviewers

The main tradeoff here is intentional: this restores browser-side dependency telemetry that had previously been disabled to reduce noise. That follows the Microsoft Learn guidance more closely and is what enables the end-to-end trace view. The TryDotNet support includes a small project-specific compatibility layer in addition to the standard App Insights/OpenTelemetry propagation path.