### PR TITLE
fix: gate Azure Monitor profiler on supported platforms

### DIFF
--- a/.github/workflows/macos-build-and-test.yml
+++ b/.github/workflows/macos-build-and-test.yml
@@ -1,0 +1,50 @@
+name: macOS Build and Test EssentialCSharp.Web
+
+on:
+  pull_request:
+    branches: ["main"]
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "26"
+          cache: npm
+          cache-dependency-path: EssentialCSharp.Web/package-lock.json
+
+      - name: Set up dependency caching for faster builds
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.nuget/packages
+            ${{ github.workspace }}/**/obj/project.assets.json
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+            ${{ runner.os }}-nuget-
+
+      - name: Restore with dotnet
+        run: dotnet restore /p:AccessToNugetFeed=false
+
+      - name: Install npm dependencies
+        working-directory: EssentialCSharp.Web
+        run: npm ci
+
+      - name: Build with dotnet
+        run: dotnet build --configuration Release --no-restore /p:AccessToNugetFeed=false
+
+      - name: Run .NET Tests
+        run: dotnet test --no-build --configuration Release

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -51,6 +51,7 @@ public partial class Program
         string? appInsightsConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
         bool useAzureMonitor = !string.IsNullOrWhiteSpace(appInsightsConnectionString);
         bool useOtlp = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+        bool profilerSupportedPlatform = OperatingSystem.IsWindows() || OperatingSystem.IsLinux();
 
         builder.Logging.AddOpenTelemetry(logging =>
         {
@@ -91,7 +92,13 @@ public partial class Program
             });
 
         if (useAzureMonitor)
-            otel.UseAzureMonitor().AddAzureMonitorProfiler();
+        {
+            // Azure Monitor export is supported cross-platform, but the profiler currently only
+            // supports Windows and Linux.
+            var azureMonitor = otel.UseAzureMonitor();
+            if (profilerSupportedPlatform)
+                azureMonitor.AddAzureMonitorProfiler();
+        }
         else if (useOtlp)
             otel.UseOtlpExporter();
 


### PR DESCRIPTION
macOS startup currently fails because the Azure Monitor profiler is registered unconditionally even though that component only supports Windows and Linux. This change keeps Azure Monitor export enabled cross-platform while avoiding profiler registration on unsupported platforms.

It also adds a small macOS GitHub Actions smoke workflow so restore, build, and test run on `macos-latest` for pull requests and merge groups. That gives us lightweight platform coverage for this class of regression without changing the existing Ubuntu-focused CI path.

## What changed

- gate `AddAzureMonitorProfiler()` behind a Windows/Linux platform check
- keep the existing Azure Monitor and OTLP branching behavior intact
- add a dedicated macOS workflow that runs restore, frontend dependency install, build, and test

## Notes

- the new workflow uses `/p:AccessToNugetFeed=false` to match the repo's public CI behavior
- this is intentionally a smoke path, not a full duplicate of the main PR workflow