### PR TITLE
fix(appinsights): set browser app id for correlation

### DIFF
--- a/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
+++ b/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
@@ -194,6 +194,7 @@
         window.IS_AUTHENTICATED = @Json.Serialize(SignInManager.IsSignedIn(User));
         window.TRYDOTNET_ORIGIN = @Json.Serialize(Configuration["TryDotNet:Origin"]);
         window.APPLICATIONINSIGHTS_CONNECTION_STRING = @Json.Serialize(Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]);
+        window.APPLICATIONINSIGHTS_APP_ID = @Json.Serialize(Configuration["APPLICATIONINSIGHTS_APP_ID"]);
         window.BUILD_LABEL = @Json.Serialize(buildLabel);
         window.ENABLE_CHAT_WIDGET = @Json.Serialize(!Context.Request.Path.StartsWithSegments("/Identity"));
         window.HCAPTCHA_SITE_KEY = @Json.Serialize(chatCaptchaSiteKey);

--- a/EssentialCSharp.Web/wwwroot/js/appinsights-manager.js
+++ b/EssentialCSharp.Web/wwwroot/js/appinsights-manager.js
@@ -20,6 +20,11 @@
         return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
     }
 
+    function getAppId() {
+        const value = window.APPLICATIONINSIGHTS_APP_ID;
+        return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+    }
+
     function getTryDotNetOrigin() {
         const value = window.TRYDOTNET_ORIGIN;
         return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -137,9 +142,12 @@
         const instance = new window.Microsoft.ApplicationInsights.ApplicationInsights({
             config: {
                 connectionString,
+                appId: getAppId(),
                 disableAjaxTracking: false,
                 disableFetchTracking: false,
                 distributedTracingMode: DistributedTracingModes.W3C,
+                // Restrict correlation headers to the app's own origins so the browser trace
+                // continues across the main site and the Try iframe without leaking headers to unrelated hosts.
                 correlationHeaderDomains: getCorrelationHeaderDomains(),
                 enableCorsCorrelation: true,
                 disableTelemetry: false


### PR DESCRIPTION
## Summary\n- expose the Application Insights app id to the browser\n- configure the browser SDK with the app id for client/server correlation\n- keep correlation headers limited to the web and Try origins\n\n## Testing\n- dotnet build EssentialCSharp.Web.slnx -c Release /p:AccessToNugetFeed=false