### PR TITLE
feat: add Kindle-style reading time tracker

### DIFF
--- a/EssentialCSharp.Web.Tests/ReadingControllerTests.cs
+++ b/EssentialCSharp.Web.Tests/ReadingControllerTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Net.Http.Json;
+using EssentialCSharp.Web.Controllers;
+
+namespace EssentialCSharp.Web.Tests;
+
+public class ReadingControllerTests : IntegrationTestBase
+{
+
+    [Test]
+    public async Task GetBookStats_IsPublic_Returns200()
+    {
+        using HttpClient client = CreateClientWithoutAutoRedirect();
+        using HttpResponseMessage response = await client.GetAsync("/api/reading/book-stats");
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task GetBookStats_ReturnsExpectedShape()
+    {
+        using HttpClient client = CreateClientWithoutAutoRedirect();
+        using HttpResponseMessage response = await client.GetAsync("/api/reading/book-stats");
+
+        var body = await response.Content.ReadFromJsonAsync<BookStatsResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.TotalWordCount).IsGreaterThanOrEqualTo(0);
+        await Assert.That(body.Chapters).IsNotNull();
+    }
+
+    // ---- profile (requires auth) ----
+
+    [Test]
+    public async Task GetProfile_Anonymous_Returns401()
+    {
+        using HttpClient client = CreateClientWithoutAutoRedirect();
+        using HttpResponseMessage response = await client.GetAsync("/api/reading/profile");
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+    }
+
+    // ---- POST session (requires auth) ----
+
+    [Test]
+    public async Task PostSession_Anonymous_Returns401()
+    {
+        using HttpClient client = CreateClientWithoutAutoRedirect();
+        var intervals = new[]
+        {
+            new ReadingController.ReadingIntervalDto("page1", 60, 100, false)
+        };
+        using HttpResponseMessage response = await client.PostAsJsonAsync("/api/reading/session", intervals);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+    }
+
+    // ---- POST reset (requires auth) ----
+
+    [Test]
+    public async Task PostReset_Anonymous_Returns401()
+    {
+        using HttpClient client = CreateClientWithoutAutoRedirect();
+        using HttpResponseMessage response = await client.PostAsync("/api/reading/reset", null);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+    }
+
+    // ---- WPM algorithm unit tests (test logic directly, no HTTP) ----
+
+    [Test]
+    public async Task WpmAlgorithm_FastInterval_IsDiscarded()
+    {
+        // Hard discard: >900 WPM → interval dropped entirely
+        long discardWords = 901;
+        long discardSeconds = 60;
+        double discardWpm = discardWords / (discardSeconds / 60.0); // 901 WPM
+
+        await Assert.That(discardWpm).IsGreaterThan(900.0);
+
+        // Accepted interval: 600 WPM (below cutoff)
+        long acceptWords = 600;
+        long acceptSeconds = 60;
+        double acceptWpm = acceptWords / (acceptSeconds / 60.0); // 600 WPM
+
+        await Assert.That(acceptWpm).IsLessThanOrEqualTo(900.0);
+    }
+
+    [Test]
+    public async Task WpmAlgorithm_SlowInterval_IsClamped()
+    {
+        // Reference WPM = 200. An interval of 10 words in 300 seconds =
+        // 10 / (300/60) = 2 WPM. 0.25 * 200 = 50 WPM → interval is below threshold → clamp.
+        double referenceWpm = 200.0;
+        double slowOutlierFactor = 0.25;
+        double intervalWpm = 10.0 / (300.0 / 60.0); // ~2 WPM
+
+        bool shouldClamp = intervalWpm < slowOutlierFactor * referenceWpm;
+        await Assert.That(shouldClamp).IsTrue();
+
+        // After clamp: effectiveSeconds = words / (0.25 * referenceWpm) * 60
+        int words = 10;
+        int effectiveSeconds = (int)Math.Round(words / (slowOutlierFactor * referenceWpm) * 60.0);
+        double clampedWpm = words / (effectiveSeconds / 60.0);
+
+        // Clamped WPM should equal exactly 0.25 * referenceWpm (within rounding)
+        await Assert.That(clampedWpm).IsEqualTo(50.0).Within(1.0);
+    }
+
+    [Test]
+    public async Task WpmAlgorithm_NormalInterval_PassesThrough()
+    {
+        // 180 WPM interval with referenceWpm = 200.
+        // 180 > 0.25 * 200 = 50, so no clamping.
+        double referenceWpm = 200.0;
+        const double slowOutlierFactor = 0.25;
+        double intervalWpm = 180.0;
+
+        bool shouldClamp = intervalWpm < slowOutlierFactor * referenceWpm;
+        await Assert.That(shouldClamp).IsFalse();
+
+        bool shouldDiscard = intervalWpm > 900.0;
+        await Assert.That(shouldDiscard).IsFalse();
+    }
+
+    [Test]
+    public async Task GetBookStats_Returns200WithChapters()
+    {
+        using HttpClient client = CreateClientWithoutAutoRedirect();
+        using HttpResponseMessage response = await client.GetAsync("/api/reading/book-stats");
+        await Assert.That((int)response.StatusCode).IsEqualTo(200);
+
+        var body = await response.Content.ReadFromJsonAsync<BookStatsResponse>();
+        await Assert.That(body).IsNotNull();
+    }
+
+    // ---- DTO for deserializing book-stats response ----
+
+    private sealed class BookStatsResponse
+    {
+        public int TotalWordCount { get; set; }
+        public IEnumerable<ChapterInfo>? Chapters { get; set; }
+    }
+
+    private sealed class ChapterInfo
+    {
+        public int ChapterNumber { get; set; }
+        public int WordCount { get; set; }
+    }
+}

--- a/EssentialCSharp.Web.Tests/WordCountServiceTests.cs
+++ b/EssentialCSharp.Web.Tests/WordCountServiceTests.cs
@@ -1,0 +1,232 @@
+using EssentialCSharp.Web.Services;
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+
+namespace EssentialCSharp.Web.Tests;
+
+public class WordCountServiceTests
+{
+    // ---- Helpers ----
+
+    private static (string tempDir, string filePath) WriteTempHtmlFile(string html)
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string filePath = Path.Combine(tempDir, "page.html");
+        File.WriteAllText(filePath, html);
+        return (tempDir, filePath);
+    }
+
+    private static SiteMapping MakeMapping(string key, string contentRoot, string relativePath, int chapter, int page, int order = 1)
+    {
+        // PagePath is relative to contentRoot as individual path segments.
+        string[] segments = relativePath.Split('/', '\\').Where(s => s.Length > 0).ToArray();
+        return new SiteMapping(
+            keys: [key],
+            primaryKey: key,
+            pagePath: segments,
+            chapterNumber: chapter,
+            pageNumber: page,
+            orderOnPage: order,
+            chapterTitle: $"Chapter {chapter}",
+            rawHeading: key,
+            anchorId: key,
+            indentLevel: 0
+        );
+    }
+
+    private static (WordCountService service, string tempDir) CreateService(IList<SiteMapping> mappings, string contentRoot)
+    {
+        Mock<ISiteMappingService> siteMappingMock = new();
+        siteMappingMock.Setup(s => s.SiteMappings).Returns(mappings);
+
+        Mock<IWebHostEnvironment> envMock = new();
+        envMock.Setup(e => e.ContentRootPath).Returns(contentRoot);
+        // IWebHostEnvironment also inherits IHostEnvironment, but WordCountService only uses ContentRootPath.
+
+        var service = new WordCountService(siteMappingMock.Object, envMock.Object);
+        return (service, contentRoot);
+    }
+
+    // ---- Tests ----
+
+    [Test]
+    public async Task GetPageWordCount_PlainProse_ReturnsCorrectCount()
+    {
+        // Arrange
+        const string html = "<html><body><p>Hello world this is a test.</p></body></html>";
+        (string tempDir, string filePath) = WriteTempHtmlFile(html);
+        try
+        {
+            string relativePath = Path.GetFileName(filePath);
+            SiteMapping mapping = MakeMapping("page1", tempDir, relativePath, 1, 1);
+            (WordCountService service, _) = CreateService([mapping], tempDir);
+
+            // Act
+            int count = service.GetPageWordCount("page1");
+
+            // Assert — "Hello world this is a test." = 6 words
+            await Assert.That(count).IsEqualTo(6);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task GetPageWordCount_ExcludesPreAndCodeBlocks()
+    {
+        // Arrange — 3 prose words + code block that should be excluded
+        const string html = """
+            <html><body>
+                <p>Hello world prose.</p>
+                <pre>public static void Main() { var x = 1; }</pre>
+                <code>Console.WriteLine(x);</code>
+            </body></html>
+            """;
+        (string tempDir, string filePath) = WriteTempHtmlFile(html);
+        try
+        {
+            string relativePath = Path.GetFileName(filePath);
+            SiteMapping mapping = MakeMapping("page2", tempDir, relativePath, 1, 1);
+            (WordCountService service, _) = CreateService([mapping], tempDir);
+
+            // Act
+            int count = service.GetPageWordCount("page2");
+
+            // Assert — only "Hello world prose." = 3 words
+            await Assert.That(count).IsEqualTo(3);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task GetPageWordCount_ExcludesScriptAndStyle()
+    {
+        const string html = """
+            <html><head><style>body { margin: 0; }</style></head>
+            <body>
+                <p>Two words.</p>
+                <script>var x = 1;</script>
+            </body></html>
+            """;
+        (string tempDir, string filePath) = WriteTempHtmlFile(html);
+        try
+        {
+            string relativePath = Path.GetFileName(filePath);
+            SiteMapping mapping = MakeMapping("page3", tempDir, relativePath, 1, 1);
+            (WordCountService service, _) = CreateService([mapping], tempDir);
+
+            int count = service.GetPageWordCount("page3");
+
+            // "Two words." = 2
+            await Assert.That(count).IsEqualTo(2);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task GetPageWordCount_FileNotFound_ReturnsZero()
+    {
+        // Arrange — map a page that doesn't have a corresponding file
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            SiteMapping mapping = MakeMapping("missing", tempDir, "nonexistent.html", 1, 1);
+            (WordCountService service, _) = CreateService([mapping], tempDir);
+
+            int count = service.GetPageWordCount("missing");
+
+            await Assert.That(count).IsEqualTo(0);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task GetChapterWordCount_SumsAllPagesInChapter()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Page A: 3 words; Page B: 4 words → chapter total 7
+            File.WriteAllText(Path.Combine(tempDir, "a.html"), "<html><body><p>one two three</p></body></html>");
+            File.WriteAllText(Path.Combine(tempDir, "b.html"), "<html><body><p>four five six seven</p></body></html>");
+
+            SiteMapping[] mappings =
+            [
+                MakeMapping("a", tempDir, "a.html", 1, 1),
+                MakeMapping("b", tempDir, "b.html", 1, 2),
+            ];
+            (WordCountService service, _) = CreateService(mappings, tempDir);
+
+            await Assert.That(service.GetChapterWordCount(1)).IsEqualTo(7);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task GetBookWordCount_SumsAllChapters()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "ch1.html"), "<html><body><p>alpha beta</p></body></html>");      // 2 words
+            File.WriteAllText(Path.Combine(tempDir, "ch2.html"), "<html><body><p>gamma delta epsilon</p></body></html>"); // 3 words
+
+            SiteMapping[] mappings =
+            [
+                MakeMapping("ch1", tempDir, "ch1.html", 1, 1),
+                MakeMapping("ch2", tempDir, "ch2.html", 2, 1),
+            ];
+            (WordCountService service, _) = CreateService(mappings, tempDir);
+
+            await Assert.That(service.GetBookWordCount()).IsEqualTo(5);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task GetWordsBeforePage_ReturnsCorrectPrefixSum()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "p1.html"), "<html><body><p>one two</p></body></html>"); // 2 words
+            File.WriteAllText(Path.Combine(tempDir, "p2.html"), "<html><body><p>three</p></body></html>");   // 1 word
+
+            SiteMapping[] mappings =
+            [
+                MakeMapping("p1", tempDir, "p1.html", 1, 1),
+                MakeMapping("p2", tempDir, "p2.html", 1, 2),
+            ];
+            (WordCountService service, _) = CreateService(mappings, tempDir);
+
+            await Assert.That(service.GetWordsBeforePage("p1")).IsEqualTo(0); // first page
+            await Assert.That(service.GetWordsBeforePage("p2")).IsEqualTo(2); // 2 words from p1
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/EssentialCSharp.Web/Areas/Identity/Data/EssentialCSharpWebContext.cs
+++ b/EssentialCSharp.Web/Areas/Identity/Data/EssentialCSharpWebContext.cs
@@ -11,9 +11,28 @@ public class EssentialCSharpWebContext(DbContextOptions<EssentialCSharpWebContex
 {
     public DbSet<DataProtectionKey> DataProtectionKeys { get; set; } = null!;
     public DbSet<McpApiToken> McpApiTokens { get; set; } = null!;
+    public DbSet<ReadingActivity> ReadingActivities { get; set; } = null!;
+    public DbSet<UserReadingProfile> UserReadingProfiles { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
+
+        builder.Entity<UserReadingProfile>(entity =>
+        {
+            entity.HasKey(e => e.UserId);
+            entity.HasOne(e => e.User)
+                  .WithOne()
+                  .HasForeignKey<UserReadingProfile>(e => e.UserId)
+                  .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        builder.Entity<ReadingActivity>(entity =>
+        {
+            entity.HasOne(e => e.User)
+                  .WithMany()
+                  .HasForeignKey(e => e.UserId)
+                  .OnDelete(DeleteBehavior.Cascade);
+        });
     }
 }

--- a/EssentialCSharp.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml
+++ b/EssentialCSharp.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml
@@ -35,9 +35,54 @@ ViewData["ActivePage"] = ManageNavPages.Index;
             </div>
             <button id="update-profile-button" type="submit" class="w-100 btn btn-lg btn-primary">Save</button>
         </form>
+
+        <hr class="mt-4" />
+        <h4>Reading Speed</h4>
+        <p class="text-muted small">
+            Essential C# tracks your reading speed to estimate how long chapters and the book will take you.
+            Resetting clears all recorded data and returns to the default estimate.
+        </p>
+        <button id="reset-reading-speed-button" type="button" class="btn btn-outline-danger"
+                data-confirm="Reset your reading speed? This cannot be undone.">
+            Reset reading speed
+        </button>
+        <div id="reset-reading-status" class="mt-2 small" style="display:none;"></div>
     </div>
 </div>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        (function () {
+            const btn = document.getElementById('reset-reading-speed-button');
+            const status = document.getElementById('reset-reading-status');
+            if (!btn) return;
+
+            btn.addEventListener('click', async function () {
+                if (!confirm(btn.dataset.confirm)) return;
+
+                btn.disabled = true;
+                status.style.display = '';
+                status.textContent = 'Resetting…';
+                status.className = 'mt-2 small text-muted';
+
+                try {
+                    const res = await fetch('/api/reading/reset', { method: 'POST' });
+                    if (res.ok) {
+                        try { localStorage.removeItem('readingProfile'); } catch {}
+                        status.textContent = 'Reading speed reset successfully.';
+                        status.className = 'mt-2 small text-success';
+                    } else {
+                        status.textContent = 'Reset failed. Please try again.';
+                        status.className = 'mt-2 small text-danger';
+                        btn.disabled = false;
+                    }
+                } catch {
+                    status.textContent = 'Network error. Please try again.';
+                    status.className = 'mt-2 small text-danger';
+                    btn.disabled = false;
+                }
+            });
+        })();
+    </script>
 }

--- a/EssentialCSharp.Web/Controllers/HomeController.cs
+++ b/EssentialCSharp.Web/Controllers/HomeController.cs
@@ -34,16 +34,17 @@ public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment 
             string headHtml = doc.DocumentNode.Element("html").Element("head").InnerHtml;
             string html = doc.DocumentNode.Element("html").Element("body").InnerHtml;
 
+            string pageKey = siteMapping.Keys.FirstOrDefault() ?? siteMapping.PrimaryKey ?? string.Empty;
             ViewBag.PageTitle = siteMapping.IndentLevel is 0 ? siteMapping.ChapterTitle + " " + siteMapping.RawHeading : siteMapping.RawHeading;
             ViewBag.NextPage = FlipPage(siteMapping!.ChapterNumber, siteMapping.PageNumber, true);
-            ViewBag.CurrentPageKey = siteMapping.PrimaryKey;
+            ViewBag.CurrentPageKey = pageKey;
             ViewBag.PreviousPage = FlipPage(siteMapping.ChapterNumber, siteMapping.PageNumber, false);
             ViewBag.HeadContents = headHtml;
             ViewBag.Contents = html;
-            ViewBag.PageWordCount = wordCountService.GetPageWordCount(siteMapping.PrimaryKey);
+            ViewBag.PageWordCount = wordCountService.GetPageWordCount(pageKey);
             ViewBag.ChapterWordCount = wordCountService.GetChapterWordCount(siteMapping.ChapterNumber);
-            ViewBag.WordsBeforePage = wordCountService.GetWordsBeforePage(siteMapping.PrimaryKey);
-            ViewBag.ChapterStartWords = wordCountService.GetChapterStartWords(siteMapping.PrimaryKey);
+            ViewBag.WordsBeforePage = wordCountService.GetWordsBeforePage(pageKey);
+            ViewBag.ChapterStartWords = wordCountService.GetChapterStartWords(pageKey);
             ViewBag.BookWordCount = wordCountService.GetBookWordCount();
             return View();
         }

--- a/EssentialCSharp.Web/Controllers/HomeController.cs
+++ b/EssentialCSharp.Web/Controllers/HomeController.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Options;
 
 namespace EssentialCSharp.Web.Controllers;
 
-public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment hostingEnvironment, ISiteMappingService siteMappingService, IHttpContextAccessor httpContextAccessor, IRouteConfigurationService routeConfigurationService, IOptions<SiteSettings> siteSettings) : BaseController(routeConfigurationService, httpContextAccessor)
+public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment hostingEnvironment, ISiteMappingService siteMappingService, IHttpContextAccessor httpContextAccessor, IRouteConfigurationService routeConfigurationService, IOptions<SiteSettings> siteSettings, IWordCountService wordCountService) : BaseController(routeConfigurationService, httpContextAccessor)
 {
     [EnableRateLimiting("content")]
     public IActionResult Index()
@@ -40,6 +40,11 @@ public class HomeController(ILogger<HomeController> logger, IWebHostEnvironment 
             ViewBag.PreviousPage = FlipPage(siteMapping.ChapterNumber, siteMapping.PageNumber, false);
             ViewBag.HeadContents = headHtml;
             ViewBag.Contents = html;
+            ViewBag.PageWordCount = wordCountService.GetPageWordCount(siteMapping.PrimaryKey);
+            ViewBag.ChapterWordCount = wordCountService.GetChapterWordCount(siteMapping.ChapterNumber);
+            ViewBag.WordsBeforePage = wordCountService.GetWordsBeforePage(siteMapping.PrimaryKey);
+            ViewBag.ChapterStartWords = wordCountService.GetChapterStartWords(siteMapping.PrimaryKey);
+            ViewBag.BookWordCount = wordCountService.GetBookWordCount();
             return View();
         }
         else

--- a/EssentialCSharp.Web/Controllers/ReadingController.cs
+++ b/EssentialCSharp.Web/Controllers/ReadingController.cs
@@ -1,0 +1,253 @@
+using System.Security.Claims;
+using EssentialCSharp.Web.Data;
+using EssentialCSharp.Web.Models;
+using EssentialCSharp.Web.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace EssentialCSharp.Web.Controllers;
+
+[ApiController]
+[Route("api/reading")]
+public partial class ReadingController(
+    EssentialCSharpWebContext context,
+    IWordCountService wordCountService,
+    ILogger<ReadingController> logger) : ControllerBase
+{
+    // Algorithm constants (mirrors Kindle's ReadingTimer values).
+    private const int MaxWpmHardCutoff = 900;
+    private const double SlowOutlierFactor = 0.25;
+    private const int MaxReadingActivityRowsPerUser = 500;
+
+    // High-performance logger messages (CA1848).
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Discarding interval for {PageKey}: {Wpm:F0} WPM exceeds hard cutoff of {Cutoff}")]
+    private static partial void LogIntervalDiscarded(ILogger logger, string pageKey, double wpm, int cutoff);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Clamping slow interval for {PageKey}: {Wpm:F0} WPM → effective {EffSeconds}s")]
+    private static partial void LogIntervalClamped(ILogger logger, string pageKey, double wpm, int effSeconds);
+
+    // -------------------------------------------------------------------------
+    // GET /api/reading/book-stats  (public — used by anonymous clients too)
+    // -------------------------------------------------------------------------
+
+    [HttpGet("book-stats")]
+    public IActionResult GetBookStats()
+    {
+        var chapters = wordCountService.GetChapterWordCounts()
+            .Select(c => new { chapterNumber = c.ChapterNumber, wordCount = c.WordCount });
+
+        return Ok(new
+        {
+            totalWordCount = wordCountService.GetBookWordCount(),
+            chapters
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/reading/profile  (authenticated)
+    // -------------------------------------------------------------------------
+
+    [HttpGet("profile")]
+    [Authorize]
+    public async Task<IActionResult> GetProfile(CancellationToken cancellationToken)
+    {
+        string userId = GetUserId();
+
+        UserReadingProfile? profile = await context.UserReadingProfiles
+            .FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
+
+        if (profile is null)
+        {
+            return Ok(new { totalWordsRead = 0L, totalActiveSeconds = 0L, wpm = (double?)null });
+        }
+
+        return Ok(new
+        {
+            totalWordsRead = profile.TotalWordsRead,
+            totalActiveSeconds = profile.TotalActiveSeconds,
+            wpm = profile.DeriveWpm()
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/reading/session  (authenticated)
+    // -------------------------------------------------------------------------
+
+    public record ReadingIntervalDto(
+        string PageKey,
+        int ActiveSeconds,
+        int WordsRead,
+        bool Completed);
+
+    [HttpPost("session")]
+    [Authorize]
+    public async Task<IActionResult> PostSession(
+        [FromBody] IEnumerable<ReadingIntervalDto> intervals,
+        CancellationToken cancellationToken)
+    {
+        string userId = GetUserId();
+
+        if (intervals is null)
+        {
+            return BadRequest("intervals is required");
+        }
+
+        List<ReadingIntervalDto> intervalList = intervals.ToList();
+        if (intervalList.Count == 0)
+        {
+            return Ok();
+        }
+
+        // Load or create profile (used as reference WPM for outlier clamping).
+        UserReadingProfile? profile = await context.UserReadingProfiles
+            .FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
+
+        double referenceWpm = profile?.DeriveWpm() ?? 0;
+
+        long deltaWords = 0;
+        long deltaSeconds = 0;
+        var activities = new List<ReadingActivity>(intervalList.Count);
+
+        foreach (ReadingIntervalDto interval in intervalList)
+        {
+            if (interval.ActiveSeconds <= 0 || interval.WordsRead <= 0)
+            {
+                continue;
+            }
+
+            double intervalWpm = interval.WordsRead / (interval.ActiveSeconds / 60.0);
+
+            // Hard discard: too fast to be genuine reading.
+            if (intervalWpm > MaxWpmHardCutoff)
+            {
+                LogIntervalDiscarded(logger, interval.PageKey, intervalWpm, MaxWpmHardCutoff);
+                continue;
+            }
+
+            // Soft clamp: interval is implausibly slow relative to reader's own rate.
+            int effectiveWords = interval.WordsRead;
+            int effectiveSeconds = interval.ActiveSeconds;
+            if (referenceWpm > 0 && intervalWpm < SlowOutlierFactor * referenceWpm)
+            {
+                // Clamp: keep the words, shrink the time so effective WPM = 0.25 × referenceWpm.
+                effectiveSeconds = (int)Math.Round(effectiveWords / (SlowOutlierFactor * referenceWpm) * 60.0);
+                LogIntervalClamped(logger, interval.PageKey, intervalWpm, effectiveSeconds);
+            }
+
+            deltaWords += effectiveWords;
+            deltaSeconds += effectiveSeconds;
+
+            activities.Add(new ReadingActivity
+            {
+                UserId = userId,
+                PageKey = interval.PageKey,
+                RecordedAtUtc = DateTime.UtcNow,
+                ActiveSeconds = interval.ActiveSeconds,
+                WordsRead = interval.WordsRead,
+                Completed = interval.Completed
+            });
+        }
+
+        // Persist inside a single transaction: insert detail rows, update aggregate, trim retention.
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            if (activities.Count > 0)
+            {
+                await context.ReadingActivities.AddRangeAsync(activities, cancellationToken);
+            }
+
+            if (deltaWords > 0 || deltaSeconds > 0)
+            {
+                if (profile is null)
+                {
+                    profile = new UserReadingProfile
+                    {
+                        UserId = userId,
+                        TotalWordsRead = deltaWords,
+                        TotalActiveSeconds = deltaSeconds,
+                        UpdatedAtUtc = DateTime.UtcNow
+                    };
+                    context.UserReadingProfiles.Add(profile);
+                }
+                else
+                {
+                    profile.TotalWordsRead += deltaWords;
+                    profile.TotalActiveSeconds += deltaSeconds;
+                    profile.UpdatedAtUtc = DateTime.UtcNow;
+                }
+            }
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            // Trim ReadingActivity to the newest 500 rows for this user.
+            // We do this after SaveChanges so the new rows are visible in the sub-query.
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                DELETE FROM [ReadingActivities]
+                WHERE [UserId] = {0}
+                  AND [Id] NOT IN (
+                    SELECT TOP ({1}) [Id]
+                    FROM [ReadingActivities]
+                    WHERE [UserId] = {0}
+                    ORDER BY [RecordedAtUtc] DESC
+                  )
+                """,
+                [userId, MaxReadingActivityRowsPerUser],
+                cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+
+        return Ok(new
+        {
+            totalWordsRead = profile?.TotalWordsRead ?? 0,
+            totalActiveSeconds = profile?.TotalActiveSeconds ?? 0,
+            wpm = profile?.DeriveWpm()
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/reading/reset  (authenticated)
+    // -------------------------------------------------------------------------
+
+    [HttpPost("reset")]
+    [Authorize]
+    public async Task<IActionResult> Reset(CancellationToken cancellationToken)
+    {
+        string userId = GetUserId();
+
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            await context.ReadingActivities
+                .Where(a => a.UserId == userId)
+                .ExecuteDeleteAsync(cancellationToken);
+
+            await context.UserReadingProfiles
+                .Where(p => p.UserId == userId)
+                .ExecuteDeleteAsync(cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+
+        return Ok();
+    }
+
+    // -------------------------------------------------------------------------
+
+    private string GetUserId() =>
+        User.FindFirstValue(ClaimTypes.NameIdentifier)
+        ?? throw new InvalidOperationException("Authenticated user has no NameIdentifier claim.");
+}

--- a/EssentialCSharp.Web/Migrations/20260809064123_AddReadingTimeTracking.Designer.cs
+++ b/EssentialCSharp.Web/Migrations/20260809064123_AddReadingTimeTracking.Designer.cs
@@ -4,6 +4,7 @@ using EssentialCSharp.Web.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EssentialCSharp.Web.Migrations
 {
     [DbContext(typeof(EssentialCSharpWebContext))]
-    partial class EssentialCSharpWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260809064123_AddReadingTimeTracking")]
+    partial class AddReadingTimeTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EssentialCSharp.Web/Migrations/20260809064123_AddReadingTimeTracking.cs
+++ b/EssentialCSharp.Web/Migrations/20260809064123_AddReadingTimeTracking.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+#pragma warning disable CA1861
+
+namespace EssentialCSharp.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReadingTimeTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReadingActivities",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    PageKey = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    RecordedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ActiveSeconds = table.Column<int>(type: "int", nullable: false),
+                    WordsRead = table.Column<int>(type: "int", nullable: false),
+                    Completed = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReadingActivities", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ReadingActivities_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserReadingProfiles",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    TotalWordsRead = table.Column<long>(type: "bigint", nullable: false),
+                    TotalActiveSeconds = table.Column<long>(type: "bigint", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserReadingProfiles", x => x.UserId);
+                    table.ForeignKey(
+                        name: "FK_UserReadingProfiles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingActivities_UserId_PageKey",
+                table: "ReadingActivities",
+                columns: new[] { "UserId", "PageKey" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingActivities_UserId_RecordedAtUtc",
+                table: "ReadingActivities",
+                columns: new[] { "UserId", "RecordedAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReadingActivities");
+
+            migrationBuilder.DropTable(
+                name: "UserReadingProfiles");
+        }
+    }
+}

--- a/EssentialCSharp.Web/Models/ReadingActivity.cs
+++ b/EssentialCSharp.Web/Models/ReadingActivity.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using EssentialCSharp.Web.Areas.Identity.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace EssentialCSharp.Web.Models;
+
+/// <summary>
+/// Records a single reading interval for a content page.
+/// This is an audit/detail trail; the WPM math reads only
+/// <see cref="UserReadingProfile"/>.
+/// </summary>
+[Index(nameof(UserId), nameof(RecordedAtUtc))]
+[Index(nameof(UserId), nameof(PageKey))]
+public class ReadingActivity
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(450)]
+    public required string UserId { get; set; }
+
+    /// <summary>
+    /// Matches <see cref="SiteMapping.PrimaryKey"/> for the page that was read.
+    /// </summary>
+    [Required]
+    [MaxLength(256)]
+    public required string PageKey { get; set; }
+
+    public DateTime RecordedAtUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Active (non-idle, non-hidden) seconds spent on this page.</summary>
+    public int ActiveSeconds { get; set; }
+
+    /// <summary>Prose words credited to this reading interval (may be fractional for partial reads, rounded to int).</summary>
+    public int WordsRead { get; set; }
+
+    /// <summary>True when the reader reached the bottom of the page content.</summary>
+    public bool Completed { get; set; }
+
+    public EssentialCSharpWebUser? User { get; set; }
+}

--- a/EssentialCSharp.Web/Models/UserReadingProfile.cs
+++ b/EssentialCSharp.Web/Models/UserReadingProfile.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+using EssentialCSharp.Web.Areas.Identity.Data;
+
+namespace EssentialCSharp.Web.Models;
+
+/// <summary>
+/// Aggregate reading profile for a single user.
+/// WPM is always derived as <c>TotalWordsRead / (TotalActiveSeconds / 60.0)</c>;
+/// it is never stored directly so there is no floating-point drift over time.
+/// </summary>
+public class UserReadingProfile
+{
+    /// <summary>Primary key — also the FK to <see cref="EssentialCSharpWebUser"/>.</summary>
+    [Required]
+    [MaxLength(450)]
+    public required string UserId { get; set; }
+
+    /// <summary>
+    /// Cumulative prose words credited across all accepted, clamped reading intervals.
+    /// </summary>
+    public long TotalWordsRead { get; set; }
+
+    /// <summary>
+    /// Cumulative active seconds across all accepted, clamped reading intervals.
+    /// </summary>
+    public long TotalActiveSeconds { get; set; }
+
+    public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public EssentialCSharpWebUser? User { get; set; }
+
+    /// <summary>
+    /// Derives the current words-per-minute estimate. Returns null if insufficient data.
+    /// </summary>
+    public double? DeriveWpm() =>
+        TotalActiveSeconds > 0 ? TotalWordsRead / (TotalActiveSeconds / 60.0) : null;
+}

--- a/EssentialCSharp.Web/Program.cs
+++ b/EssentialCSharp.Web/Program.cs
@@ -270,6 +270,7 @@ public partial class Program
         builder.Services.AddSingleton<IRouteConfigurationService, RouteConfigurationService>();
         builder.Services.AddSingleton<IListingSourceCodeService, ListingSourceCodeService>();
         builder.Services.AddSingleton<IBookToolQueryService, BookToolQueryService>();
+        builder.Services.AddSingleton<IWordCountService, WordCountService>();
         builder.Services.AddScoped<IReferralService, ReferralService>();
 
         // Add AI Chat services using configuration-driven backend selection.

--- a/EssentialCSharp.Web/Services/IWordCountService.cs
+++ b/EssentialCSharp.Web/Services/IWordCountService.cs
@@ -1,0 +1,35 @@
+namespace EssentialCSharp.Web.Services;
+
+/// <summary>
+/// Provides pre-computed prose word counts for content pages, enabling
+/// Kindle-style reading time estimates.
+/// </summary>
+public interface IWordCountService
+{
+    /// <summary>Gets the prose word count for a specific page key.</summary>
+    int GetPageWordCount(string pageKey);
+
+    /// <summary>Gets the total prose word count for a chapter.</summary>
+    int GetChapterWordCount(int chapterNumber);
+
+    /// <summary>Gets the total prose word count for the entire book.</summary>
+    int GetBookWordCount();
+
+    /// <summary>
+    /// Gets the number of prose words before the given page (across the entire book).
+    /// Used for "words remaining in book" math.
+    /// </summary>
+    int GetWordsBeforePage(string pageKey);
+
+    /// <summary>
+    /// Gets the number of prose words before the given page within its chapter.
+    /// Used for "words remaining in chapter" math.
+    /// </summary>
+    int GetChapterStartWords(string pageKey);
+
+    /// <summary>Gets per-chapter word count summary for the book-stats API response.</summary>
+    IReadOnlyList<ChapterWordCount> GetChapterWordCounts();
+}
+
+/// <summary>Per-chapter word count summary returned by the book-stats API.</summary>
+public record ChapterWordCount(int ChapterNumber, int WordCount);

--- a/EssentialCSharp.Web/Services/WordCountService.cs
+++ b/EssentialCSharp.Web/Services/WordCountService.cs
@@ -1,0 +1,154 @@
+using HtmlAgilityPack;
+
+namespace EssentialCSharp.Web.Services;
+
+/// <summary>
+/// Singleton service that computes prose-only word counts for all content pages
+/// at startup and caches them in memory. Code blocks (<c>&lt;pre&gt;</c>,
+/// <c>&lt;code&gt;</c>, <c>&lt;script&gt;</c>, <c>&lt;style&gt;</c>) are excluded
+/// because they are read very differently from prose and would skew WPM estimates.
+/// </summary>
+public class WordCountService : IWordCountService
+{
+    // Tags whose text content is excluded from prose word counts.
+    private static readonly HashSet<string> ExcludedTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "pre", "code", "script", "style"
+    };
+
+    private readonly Dictionary<string, int> _pageWordCounts;
+    private readonly Dictionary<int, int> _chapterWordCounts;
+    private readonly int _bookWordCount;
+    private readonly Dictionary<string, int> _wordsBeforePage;
+    private readonly Dictionary<string, int> _chapterStartWords;
+    private readonly IReadOnlyList<ChapterWordCount> _chapterWordCountList;
+
+    public WordCountService(ISiteMappingService siteMappingService, IWebHostEnvironment hostingEnvironment)
+    {
+        _pageWordCounts = [];
+        _chapterWordCounts = [];
+        _wordsBeforePage = [];
+        _chapterStartWords = [];
+
+        // Walk mappings in canonical reading order: chapter → page → order-on-page.
+        IEnumerable<SiteMapping> orderedMappings = siteMappingService.SiteMappings
+            .OrderBy(m => m.ChapterNumber)
+            .ThenBy(m => m.PageNumber)
+            .ThenBy(m => m.OrderOnPage);
+
+        int bookWords = 0;
+        int currentChapter = -1;
+        int chapterWords = 0;
+        int chapterBookOffset = 0; // words before first page of current chapter in book
+
+        foreach (SiteMapping mapping in orderedMappings)
+        {
+            string pageKey = mapping.PrimaryKey;
+            if (_pageWordCounts.ContainsKey(pageKey))
+            {
+                // Multiple anchors on the same page; skip duplicates (already counted).
+                continue;
+            }
+
+            // Chapter boundary: flush previous chapter totals.
+            if (mapping.ChapterNumber != currentChapter)
+            {
+                if (currentChapter >= 0)
+                {
+                    _chapterWordCounts[currentChapter] = chapterWords;
+                }
+                currentChapter = mapping.ChapterNumber;
+                chapterBookOffset = bookWords;
+                chapterWords = 0;
+            }
+
+            int words = CountProseWords(hostingEnvironment.ContentRootPath, mapping.PagePath);
+            _pageWordCounts[pageKey] = words;
+            _wordsBeforePage[pageKey] = bookWords;
+            _chapterStartWords[pageKey] = chapterWords;
+
+            bookWords += words;
+            chapterWords += words;
+        }
+
+        // Flush the last chapter.
+        if (currentChapter >= 0)
+        {
+            _chapterWordCounts[currentChapter] = chapterWords;
+        }
+
+        _bookWordCount = bookWords;
+        _chapterWordCountList = _chapterWordCounts
+            .OrderBy(kv => kv.Key)
+            .Select(kv => new ChapterWordCount(kv.Key, kv.Value))
+            .ToList()
+            .AsReadOnly();
+    }
+
+    public int GetPageWordCount(string pageKey) =>
+        _pageWordCounts.TryGetValue(pageKey, out int count) ? count : 0;
+
+    public int GetChapterWordCount(int chapterNumber) =>
+        _chapterWordCounts.TryGetValue(chapterNumber, out int count) ? count : 0;
+
+    public int GetBookWordCount() => _bookWordCount;
+
+    public int GetWordsBeforePage(string pageKey) =>
+        _wordsBeforePage.TryGetValue(pageKey, out int count) ? count : 0;
+
+    public int GetChapterStartWords(string pageKey) =>
+        _chapterStartWords.TryGetValue(pageKey, out int count) ? count : 0;
+
+    public IReadOnlyList<ChapterWordCount> GetChapterWordCounts() => _chapterWordCountList;
+
+    // ---
+
+    private static int CountProseWords(string contentRoot, string[] pagePath)
+    {
+        string filePath = Path.Join(contentRoot, Path.Join(pagePath));
+        if (!File.Exists(filePath))
+        {
+            return 0;
+        }
+
+        HtmlDocument doc = new();
+        doc.Load(filePath);
+
+        HtmlNode? body = doc.DocumentNode.SelectSingleNode("//body") ?? doc.DocumentNode;
+
+        // Remove excluded tags (modifies in-place on a clone isn't available, so remove from live tree).
+        // XPath: //pre | //code | //script | //style
+        string xpath = string.Join(" | ", ExcludedTags.Select(t => $"//{t}"));
+        foreach (HtmlNode node in body.SelectNodes(xpath)?.ToList() ?? [])
+        {
+            node.Remove();
+        }
+
+        string text = body.InnerText;
+        return CountWords(text);
+    }
+
+    private static int CountWords(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        int count = 0;
+        bool inWord = false;
+        foreach (char c in text)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                inWord = false;
+            }
+            else if (!inWord)
+            {
+                inWord = true;
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/EssentialCSharp.Web/Services/WordCountService.cs
+++ b/EssentialCSharp.Web/Services/WordCountService.cs
@@ -43,8 +43,8 @@ public class WordCountService : IWordCountService
 
         foreach (SiteMapping mapping in orderedMappings)
         {
-            string pageKey = mapping.PrimaryKey;
-            if (_pageWordCounts.ContainsKey(pageKey))
+            string? pageKey = mapping.Keys.FirstOrDefault() ?? mapping.PrimaryKey;
+            if (pageKey is null || _pageWordCounts.ContainsKey(pageKey))
             {
                 // Multiple anchors on the same page; skip duplicates (already counted).
                 continue;

--- a/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
+++ b/EssentialCSharp.Web/Views/Shared/_Layout.cshtml
@@ -197,6 +197,12 @@
         window.BUILD_LABEL = @Json.Serialize(buildLabel);
         window.ENABLE_CHAT_WIDGET = @Json.Serialize(!Context.Request.Path.StartsWithSegments("/Identity"));
         window.HCAPTCHA_SITE_KEY = @Json.Serialize(chatCaptchaSiteKey);
+        window.CURRENT_PAGE_KEY = @Json.Serialize(ViewBag.CurrentPageKey);
+        window.PAGE_WORD_COUNT = @Json.Serialize(ViewBag.PageWordCount ?? 0);
+        window.CHAPTER_WORD_COUNT = @Json.Serialize(ViewBag.ChapterWordCount ?? 0);
+        window.WORDS_BEFORE_PAGE = @Json.Serialize(ViewBag.WordsBeforePage ?? 0);
+        window.CHAPTER_START_WORDS = @Json.Serialize(ViewBag.ChapterStartWords ?? 0);
+        window.BOOK_WORD_COUNT = @Json.Serialize(ViewBag.BookWordCount ?? 0);
     </script>
     <script src="~/dist/assets/site-shell.js" type="module" asp-append-version="true"></script>
 </body>

--- a/EssentialCSharp.Web/src/components/HeaderStatus.vue
+++ b/EssentialCSharp.Web/src/components/HeaderStatus.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { inject } from "vue";
+import ReadingTimeRemaining from "./ReadingTimeRemaining.vue";
 
 const shell = inject("shell");
 </script>
@@ -16,5 +17,6 @@ const shell = inject("shell");
         <div v-if="shell.isContentPage" class="page-menu menu-progress text-light">
             <span>{{ shell.percentComplete }}%</span>
         </div>
+        <ReadingTimeRemaining />
     </div>
 </template>

--- a/EssentialCSharp.Web/src/components/ReadingTimeRemaining.vue
+++ b/EssentialCSharp.Web/src/components/ReadingTimeRemaining.vue
@@ -1,0 +1,91 @@
+<script setup>
+import { computed, inject } from "vue";
+import { useReadingTracker } from "../composables/useReadingTracker.js";
+
+const shell = inject("shell");
+
+// Only render on chapter/content pages.
+const isContentPage = computed(() => Boolean(window.CURRENT_PAGE_KEY));
+
+// Word count data from window globals (set by _Layout.cshtml / HomeController).
+const pageWordCount = window.PAGE_WORD_COUNT ?? 0;
+const chapterWordCount = window.CHAPTER_WORD_COUNT ?? 0;
+const chapterStartWords = window.CHAPTER_START_WORDS ?? 0;
+const bookWordCount = window.BOOK_WORD_COUNT ?? 0;
+const wordsBeforePage = window.WORDS_BEFORE_PAGE ?? 0;
+
+const { wpm, activeSeconds } = useReadingTracker();
+
+// Live scroll fraction from the page.
+function getScrollFraction() {
+    const main = document.querySelector("main") ?? document.documentElement;
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const scrollable = main.scrollHeight - main.clientHeight;
+    if (scrollable <= 0) return 1;
+    return Math.min(1, Math.max(0, scrollTop / scrollable));
+}
+
+// Recomputed every second via activeSeconds dependency.
+const scrollFraction = computed(() => {
+    // Reference activeSeconds so Vue re-evaluates as the timer ticks.
+    void activeSeconds.value;
+    return getScrollFraction();
+});
+
+const wordsReadOnPage = computed(() => Math.round(pageWordCount * scrollFraction.value));
+
+const minutesLeftInChapter = computed(() => {
+    if (!wpm.value || wpm.value <= 0 || chapterWordCount <= 0) return null;
+    const wordsLeft = chapterWordCount - chapterStartWords - wordsReadOnPage.value;
+    return Math.max(0, wordsLeft) / wpm.value;
+});
+
+const minutesLeftInBook = computed(() => {
+    if (!wpm.value || wpm.value <= 0 || bookWordCount <= 0) return null;
+    const wordsLeft = bookWordCount - wordsBeforePage - wordsReadOnPage.value;
+    return Math.max(0, wordsLeft) / wpm.value;
+});
+
+function formatMinutes(minutes) {
+    if (minutes === null || minutes === undefined) return null;
+    const rounded = Math.round(minutes);
+    if (rounded < 60) {
+        return `${rounded} min`;
+    }
+    const hours = Math.floor(rounded / 60);
+    const mins = rounded % 60;
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+const chapterLabel = computed(() => {
+    const m = minutesLeftInChapter.value;
+    if (m === null) return null;
+    return `${formatMinutes(m)} left in chapter`;
+});
+
+const bookLabel = computed(() => {
+    const m = minutesLeftInBook.value;
+    if (m === null) return null;
+    return `${formatMinutes(m)} left in book`;
+});
+</script>
+
+<template>
+    <div
+        v-if="isContentPage && (chapterLabel || bookLabel)"
+        class="reading-time-remaining text-light d-flex align-items-center gap-2"
+        aria-label="Reading time remaining"
+    >
+        <span v-if="chapterLabel" class="reading-time-chapter d-none d-sm-inline">{{ chapterLabel }}</span>
+        <span v-if="chapterLabel && bookLabel" class="d-none d-lg-inline text-light opacity-50">·</span>
+        <span v-if="bookLabel" class="reading-time-book d-none d-lg-inline">{{ bookLabel }}</span>
+    </div>
+</template>
+
+<style scoped>
+.reading-time-remaining {
+    font-size: 0.8rem;
+    white-space: nowrap;
+    opacity: 0.85;
+}
+</style>

--- a/EssentialCSharp.Web/src/composables/useReadingTracker.js
+++ b/EssentialCSharp.Web/src/composables/useReadingTracker.js
@@ -1,0 +1,295 @@
+/**
+ * useReadingTracker — Kindle-style active-reading time tracker.
+ *
+ * State machine: READING → IDLE (after IDLE_THRESHOLD s of no input)
+ *                        → HIDDEN (tab not visible)
+ * Only accumulates activeSeconds while in READING state.
+ *
+ * Persists a rolling aggregate to:
+ *   - Server (POST /api/reading/session) when authenticated.
+ *   - localStorage key "readingProfile" for anonymous users and as a backup.
+ *
+ * On first authenticated page load, uploads the localStorage aggregate to the
+ * server and clears local storage (one-time sync after login).
+ */
+
+import { ref, onMounted, onBeforeUnmount, readonly } from "vue";
+
+// ----- Constants -----
+const IDLE_THRESHOLD_S = 300; // 5 minutes
+const TICK_INTERVAL_MS = 1000; // 1 second timer
+const DEFAULT_WPM = 200; // cold-start display default
+const MOUSEMOVE_THROTTLE_MS = 1000;
+const LOCAL_STORAGE_KEY = "readingProfile";
+
+// ----- States -----
+const STATE_READING = "READING";
+const STATE_IDLE = "IDLE";
+const STATE_HIDDEN = "HIDDEN";
+
+// ----- localStorage helpers -----
+
+function loadLocalProfile() {
+    try {
+        const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+        if (!raw) return { totalWords: 0, totalActiveSeconds: 0 };
+        return JSON.parse(raw);
+    } catch {
+        return { totalWords: 0, totalActiveSeconds: 0 };
+    }
+}
+
+function saveLocalProfile(profile) {
+    try {
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(profile));
+    } catch {
+        // Ignore storage errors (private browsing quota exceeded, etc.)
+    }
+}
+
+function clearLocalProfile() {
+    try {
+        localStorage.removeItem(LOCAL_STORAGE_KEY);
+    } catch {
+        // Ignore
+    }
+}
+
+// ----- API helpers -----
+
+async function fetchServerProfile() {
+    try {
+        const res = await fetch("/api/reading/profile");
+        if (!res.ok) return null;
+        return await res.json();
+    } catch {
+        return null;
+    }
+}
+
+async function postSession(intervals) {
+    if (!intervals || intervals.length === 0) return null;
+    try {
+        const res = await fetch("/api/reading/session", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(intervals)
+        });
+        if (!res.ok) return null;
+        return await res.json();
+    } catch {
+        return null;
+    }
+}
+
+// ----- Composable -----
+
+export function useReadingTracker() {
+    // Reactive WPM shown in the UI.
+    const wpm = ref(DEFAULT_WPM);
+    const activeSeconds = ref(0);
+
+    // Reading state machine.
+    let state = STATE_READING;
+    let lastActivityAt = Date.now();
+    let tickIntervalId = null;
+    let lastMousemoveAt = 0;
+
+    // Scroll tracking.
+    let maxScrollFraction = 0;
+
+    // Page context (from window globals set by _Layout.cshtml).
+    const pageKey = window.CURRENT_PAGE_KEY ?? null;
+    const pageWordCount = window.PAGE_WORD_COUNT ?? 0;
+    const isAuthenticated = Boolean(window.IS_AUTHENTICATED);
+
+    // In-session server profile for reference WPM (loaded on mount).
+    let serverProfile = null;
+
+    // ----- Scroll fraction -----
+
+    function getScrollFraction() {
+        const main = document.querySelector("main") ?? document.documentElement;
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+        const scrollable = main.scrollHeight - main.clientHeight;
+        if (scrollable <= 0) return 1;
+        return Math.min(1, Math.max(0, scrollTop / scrollable));
+    }
+
+    // ----- State machine -----
+
+    function markActivity() {
+        lastActivityAt = Date.now();
+        if (state === STATE_IDLE || state === STATE_HIDDEN) {
+            state = STATE_READING;
+        }
+    }
+
+    function onVisibilityChange() {
+        if (document.visibilityState !== "visible") {
+            state = STATE_HIDDEN;
+        } else {
+            // Tab became visible — READING if recently active, else IDLE.
+            const idleDuration = (Date.now() - lastActivityAt) / 1000;
+            state = idleDuration <= IDLE_THRESHOLD_S ? STATE_READING : STATE_IDLE;
+        }
+    }
+
+    function onMousemove() {
+        const now = Date.now();
+        if (now - lastMousemoveAt >= MOUSEMOVE_THROTTLE_MS) {
+            lastMousemoveAt = now;
+            markActivity();
+        }
+    }
+
+    function onScroll() {
+        markActivity();
+        const fraction = getScrollFraction();
+        if (fraction > maxScrollFraction) {
+            maxScrollFraction = fraction;
+        }
+    }
+
+    // ----- Tick -----
+
+    function tick() {
+        const now = Date.now();
+        const idleDuration = (now - lastActivityAt) / 1000;
+
+        if (state === STATE_READING && idleDuration > IDLE_THRESHOLD_S) {
+            state = STATE_IDLE;
+        }
+
+        if (state === STATE_READING) {
+            activeSeconds.value++;
+        }
+    }
+
+    // ----- Flush (send data on navigation away / unmount) -----
+
+    async function flush() {
+        if (!pageKey || activeSeconds.value <= 0 || pageWordCount <= 0) return;
+
+        const wordsRead = Math.round(pageWordCount * maxScrollFraction);
+        const scrollFraction = maxScrollFraction;
+        // Near-bottom (within 5%) = completed.
+        const completed = scrollFraction >= 0.95;
+
+        const interval = {
+            pageKey,
+            activeSeconds: activeSeconds.value,
+            wordsRead,
+            completed
+        };
+
+        if (isAuthenticated) {
+            const updated = await postSession([interval]);
+            if (updated) {
+                serverProfile = updated;
+                if (updated.wpm) {
+                    wpm.value = updated.wpm;
+                }
+            }
+        } else {
+            // Update localStorage profile.
+            const local = loadLocalProfile();
+            local.totalWords = (local.totalWords || 0) + wordsRead;
+            local.totalActiveSeconds = (local.totalActiveSeconds || 0) + activeSeconds.value;
+            saveLocalProfile(local);
+
+            const localWpm = local.totalActiveSeconds > 0
+                ? local.totalWords / (local.totalActiveSeconds / 60)
+                : 0;
+            if (localWpm > 0) {
+                wpm.value = localWpm;
+            }
+        }
+    }
+
+    // ----- One-time sync: localStorage → server on first authenticated load -----
+
+    async function syncLocalToServer() {
+        if (!isAuthenticated) return;
+
+        const local = loadLocalProfile();
+        if (!local || (local.totalWords === 0 && local.totalActiveSeconds === 0)) return;
+
+        // Only upload if server has no data yet.
+        const profile = await fetchServerProfile();
+        if (profile && (profile.totalWordsRead > 0 || profile.totalActiveSeconds > 0)) {
+            // Server already has data — just clear local.
+            clearLocalProfile();
+            return;
+        }
+
+        // Upload local aggregate as a synthetic interval.
+        if (local.totalWords > 0 && local.totalActiveSeconds > 0) {
+            await postSession([{
+                pageKey: "__localStorage_sync__",
+                activeSeconds: local.totalActiveSeconds,
+                wordsRead: local.totalWords,
+                completed: false
+            }]);
+        }
+        clearLocalProfile();
+    }
+
+    // ----- Init -----
+
+    onMounted(async () => {
+        // Load initial WPM.
+        if (isAuthenticated) {
+            // Try to sync localStorage first (one-time, idempotent).
+            await syncLocalToServer();
+
+            serverProfile = await fetchServerProfile();
+            if (serverProfile?.wpm) {
+                wpm.value = serverProfile.wpm;
+            }
+        } else {
+            const local = loadLocalProfile();
+            const localWpm = local.totalActiveSeconds > 0
+                ? local.totalWords / (local.totalActiveSeconds / 60)
+                : 0;
+            if (localWpm > 0) {
+                wpm.value = localWpm;
+            }
+        }
+
+        // Start tick.
+        tickIntervalId = setInterval(tick, TICK_INTERVAL_MS);
+
+        // Activity listeners.
+        document.addEventListener("visibilitychange", onVisibilityChange);
+        document.addEventListener("mousemove", onMousemove, { passive: true });
+        document.addEventListener("keydown", markActivity);
+        document.addEventListener("scroll", onScroll, { passive: true });
+        document.addEventListener("touchstart", markActivity, { passive: true });
+        document.addEventListener("pointerdown", markActivity);
+        window.addEventListener("focus", markActivity);
+
+        // Flush on page navigation (SPA or classical).
+        window.addEventListener("beforeunload", flush);
+    });
+
+    onBeforeUnmount(async () => {
+        clearInterval(tickIntervalId);
+
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+        document.removeEventListener("mousemove", onMousemove);
+        document.removeEventListener("keydown", markActivity);
+        document.removeEventListener("scroll", onScroll);
+        document.removeEventListener("touchstart", markActivity);
+        document.removeEventListener("pointerdown", markActivity);
+        window.removeEventListener("focus", markActivity);
+        window.removeEventListener("beforeunload", flush);
+
+        await flush();
+    });
+
+    return {
+        wpm: readonly(wpm),
+        activeSeconds: readonly(activeSeconds)
+    };
+}


### PR DESCRIPTION
## Summary

Adds a Kindle-style "time left in chapter / book" indicator to the EssentialCSharp.Web header, adapting to each user's actual reading speed over time.

## Features

### Server-side
- **`WordCountService`** — singleton that walks all `SiteMapping` entries at startup, strips `<pre>/<code>/<script>/<style>` via HtmlAgilityPack, and caches per-page/per-chapter/book-wide prose word counts + prefix sums (`O(1)` lookups at request time)
- **`ReadingActivity` + `UserReadingProfile`** — EF Core entities (migration `AddReadingTimeTracking`); profile stores `{totalWords, totalActiveSeconds}` for `O(1)` WPM derivation; activity rows capped at 500/user for bounded storage
- **`ReadingController`** — four endpoints:
  - `POST /api/reading/session` — batch interval ingestion, WPM algorithm (>900 WPM hard-discard; slow outliers clamped at `0.25 × referenceWpm`), aggregate update + retention trim
  - `GET /api/reading/profile` — current WPM for logged-in user
  - `GET /api/reading/book-stats` — public word counts per chapter + total
  - `POST /api/reading/reset` — clears aggregate + detail rows

### Client-side
- **`useReadingTracker.js`** composable — activity state machine (`READING` / `IDLE` / `HIDDEN`), 5-min idle threshold, instant-pause on `visibilitychange`, flush-on-navigate, localStorage→server sync on first authenticated page load
- **`ReadingTimeRemaining.vue`** — displays `"X min left in chapter · Y min left in book"` in the header; recomputes every few seconds from live scroll fraction; only renders on chapter pages; integrated into `HeaderStatus.vue`
- **`window.*` globals** — `CURRENT_PAGE_KEY`, `PAGE_WORD_COUNT`, `CHAPTER_WORD_COUNT`, `WORDS_BEFORE_PAGE`, `CHAPTER_START_WORDS`, `BOOK_WORD_COUNT` emitted from `_Layout.cshtml`

### UX
- Reset reading speed button added to Identity → Manage Profile page

## Algorithm

Mirrors Kindle's `ReadingTimer`:
- **Upper outlier**: intervals >900 WPM are discarded (page-flip/skim)
- **Lower outlier**: intervals slower than `0.25 × referenceWpm` are time-clamped (walked away mid-page)
- **Aggregate**: `totalWords / (totalActiveSeconds / 60)` — never stores a running average that needs re-weighting
- **Cold start**: 200 WPM display default (not persisted) until first accepted interval

## Testing

- `WordCountServiceTests`: prose-only counting, `<pre>/<code>` exclusion, prefix sums, chapter/book totals
- `ReadingControllerTests`: auth guards (401 on all mutating endpoints for anonymous users), WPM algorithm constant verification, `GET /api/reading/book-stats` shape test